### PR TITLE
refactor: handle one_of enum constraints in ash_type_to_nimble_options

### DIFF
--- a/lib/ash_jido/type_mapper.ex
+++ b/lib/ash_jido/type_mapper.ex
@@ -16,6 +16,7 @@ defmodule AshJido.TypeMapper do
     base_type = map_ash_type(ash_type)
 
     [type: base_type]
+    |> maybe_add_enum_constraint(field_config)
     |> maybe_add_required(field_config)
     |> maybe_add_doc(field_config)
     |> maybe_add_default(field_config)
@@ -70,4 +71,19 @@ defmodule AshJido.TypeMapper do
         options
     end
   end
+
+  # Converts Ash.Type.Atom with one_of constraints to {:in, string_values}
+  defp maybe_add_enum_constraint(opts, %{type: Ash.Type.Atom, constraints: constraints})
+       when is_list(constraints) do
+    case Keyword.get(constraints, :one_of) do
+      values when is_list(values) and values != [] ->
+        string_values = Enum.map(values, &to_string/1)
+        Keyword.put(opts, :type, {:in, string_values})
+
+      _ ->
+        opts
+    end
+  end
+
+  defp maybe_add_enum_constraint(opts, _field_config), do: opts
 end

--- a/test/ash_jido/type_mapper_test.exs
+++ b/test/ash_jido/type_mapper_test.exs
@@ -137,6 +137,20 @@ defmodule AshJido.TypeMapperTest do
       assert TypeMapper.ash_type_to_nimble_options(Ash.Type.String, options) ==
                [type: :string]
     end
+
+    test "converts Ash.Type.Atom with one_of constraints to {:in, string_values}" do
+      options = %{type: Ash.Type.Atom, constraints: [one_of: [:a, :b, :c]]}
+
+      result = TypeMapper.ash_type_to_nimble_options(Ash.Type.Atom, options)
+      assert result[:type] == {:in, ["a", "b", "c"]}
+    end
+
+    test "leaves Ash.Type.Atom as :atom when no one_of constraint" do
+      options = %{type: Ash.Type.Atom, constraints: []}
+
+      result = TypeMapper.ash_type_to_nimble_options(Ash.Type.Atom, options)
+      assert result[:type] == :atom
+    end
   end
 
   describe "edge cases and complex scenarios" do


### PR DESCRIPTION
Ash.Type.Atom fields with one_of constraints are now converted to {:in, string_values} directly by ash_type_to_nimble_options, so all callers benefit from enum constraint handling automatically.