### PR TITLE
feat: add typed_struct_to_schema for converting Ash TypedStructs to NimbleOptions schema

### DIFF
--- a/lib/ash_jido/type_mapper.ex
+++ b/lib/ash_jido/type_mapper.ex
@@ -16,6 +16,7 @@ defmodule AshJido.TypeMapper do
     base_type = map_ash_type(ash_type)
 
     [type: base_type]
+    |> maybe_add_enum_constraint(field_config)
     |> maybe_add_required(field_config)
     |> maybe_add_doc(field_config)
     |> maybe_add_default(field_config)
@@ -70,4 +71,19 @@ defmodule AshJido.TypeMapper do
         options
     end
   end
+
+  # Converts Ash.Type.Atom with one_of constraints to {:in, string_values}
+  defp maybe_add_enum_constraint(opts, %{type: Ash.Type.Atom, constraints: constraints})
+       when is_list(constraints) do
+    case Keyword.get(constraints, :one_of) do
+      values when is_list(values) and values != [] ->
+        string_values = Enum.map(values, &to_string/1)
+        Keyword.put(opts, :type, {:in, string_values})
+
+      _ ->
+        opts
+    end
+  end
+
+  defp maybe_add_enum_constraint(opts, _field_config), do: opts
 end

--- a/lib/ash_jido/type_mapper.ex
+++ b/lib/ash_jido/type_mapper.ex
@@ -23,6 +23,33 @@ defmodule AshJido.TypeMapper do
   end
 
   @doc """
+  Converts an Ash TypedStruct module to a NimbleOptions keyword list schema.
+
+  This is useful for generating structured output schemas for LLM calls
+  via ReqLLM.generate_object/4.
+
+  ## Examples
+
+      iex> AshJido.TypeMapper.typed_struct_to_schema(MyApp.PersonResult)
+      [
+        name: [type: :string, required: true, doc: "The person's name"],
+        age: [type: :integer, doc: "The person's age"]
+      ]
+  """
+  @spec typed_struct_to_schema(module()) :: keyword()
+  def typed_struct_to_schema(module) when is_atom(module) do
+    # Get field definitions from the TypedStruct's subtype_constraints
+    constraints = module.subtype_constraints()
+    fields = Keyword.get(constraints, :fields, [])
+
+    Keyword.new(fields, fn {name, field_opts} ->
+      field_config = Map.new(field_opts)
+      opts = ash_type_to_nimble_options(field_config[:type], field_config)
+      {name, opts}
+    end)
+  end
+
+  @doc """
   Maps an Ash type to its corresponding NimbleOptions type.
   """
   def map_ash_type(ash_type) do

--- a/test/ash_jido/type_mapper_test.exs
+++ b/test/ash_jido/type_mapper_test.exs
@@ -11,6 +11,7 @@ defmodule AshJido.TypeMapperTest do
   @moduletag :capture_log
 
   alias AshJido.TypeMapper
+  alias AshJido.Test.SampleExtractionResult
 
   describe "ash_type_to_nimble_options/2" do
     test "maps primitive scalar types correctly" do
@@ -178,6 +179,81 @@ defmodule AshJido.TypeMapperTest do
       assert Keyword.get(result, :required) == true
       assert Keyword.get(result, :doc) == "Complex field"
       assert Keyword.get(result, :default) == "default_value"
+    end
+  end
+
+  describe "typed_struct_to_schema/1" do
+    test "converts TypedStruct module to NimbleOptions schema" do
+      schema = TypeMapper.typed_struct_to_schema(SampleExtractionResult)
+
+      assert is_list(schema)
+      assert Keyword.keyword?(schema)
+
+      # Check that all expected fields are present
+      assert Keyword.has_key?(schema, :name)
+      assert Keyword.has_key?(schema, :age)
+      assert Keyword.has_key?(schema, :active)
+      assert Keyword.has_key?(schema, :score)
+      assert Keyword.has_key?(schema, :category)
+      assert Keyword.has_key?(schema, :tags)
+      assert Keyword.has_key?(schema, :start_date)
+    end
+
+    test "preserves field types correctly" do
+      schema = TypeMapper.typed_struct_to_schema(SampleExtractionResult)
+
+      assert schema[:name][:type] == :string
+      assert schema[:age][:type] == :integer
+      assert schema[:active][:type] == :boolean
+      assert schema[:score][:type] == :float
+      assert schema[:start_date][:type] == :string
+    end
+
+    test "preserves array types" do
+      schema = TypeMapper.typed_struct_to_schema(SampleExtractionResult)
+
+      assert schema[:tags][:type] == {:list, :string}
+    end
+
+    test "sets required: true for fields with allow_nil?: false" do
+      schema = TypeMapper.typed_struct_to_schema(SampleExtractionResult)
+
+      assert schema[:name][:required] == true
+      assert schema[:category][:required] == true
+    end
+
+    test "omits required key for optional fields" do
+      schema = TypeMapper.typed_struct_to_schema(SampleExtractionResult)
+
+      refute Keyword.has_key?(schema[:age], :required)
+      refute Keyword.has_key?(schema[:active], :required)
+      refute Keyword.has_key?(schema[:score], :required)
+      refute Keyword.has_key?(schema[:tags], :required)
+    end
+
+    test "preserves field descriptions as doc" do
+      schema = TypeMapper.typed_struct_to_schema(SampleExtractionResult)
+
+      assert schema[:name][:doc] == "The name"
+      assert schema[:age][:doc] == "The age"
+      assert schema[:score][:doc] == "Score value"
+      assert schema[:category][:doc] == "The category"
+      assert schema[:tags][:doc] == "List of tags"
+      assert schema[:start_date][:doc] == "Start date"
+    end
+
+    test "converts atom one_of constraints to {:in, values}" do
+      schema = TypeMapper.typed_struct_to_schema(SampleExtractionResult)
+
+      # Atom field with one_of constraint should be converted to {:in, string_values}
+      assert schema[:category][:type] == {:in, ["a", "b", "c"]}
+    end
+
+    test "handles fields without descriptions" do
+      schema = TypeMapper.typed_struct_to_schema(SampleExtractionResult)
+
+      # active field has no description
+      refute Keyword.has_key?(schema[:active], :doc)
     end
   end
 end

--- a/test/ash_jido/type_mapper_test.exs
+++ b/test/ash_jido/type_mapper_test.exs
@@ -137,6 +137,20 @@ defmodule AshJido.TypeMapperTest do
       assert TypeMapper.ash_type_to_nimble_options(Ash.Type.String, options) ==
                [type: :string]
     end
+
+    test "converts Ash.Type.Atom with one_of constraints to {:in, string_values}" do
+      options = %{type: Ash.Type.Atom, constraints: [one_of: [:a, :b, :c]]}
+
+      result = TypeMapper.ash_type_to_nimble_options(Ash.Type.Atom, options)
+      assert result[:type] == {:in, ["a", "b", "c"]}
+    end
+
+    test "leaves Ash.Type.Atom as :atom when no one_of constraint" do
+      options = %{type: Ash.Type.Atom, constraints: []}
+
+      result = TypeMapper.ash_type_to_nimble_options(Ash.Type.Atom, options)
+      assert result[:type] == :atom
+    end
   end
 
   describe "edge cases and complex scenarios" do

--- a/test/support/sample_extraction_result.ex
+++ b/test/support/sample_extraction_result.ex
@@ -1,0 +1,23 @@
+defmodule AshJido.Test.SampleExtractionResult do
+  @moduledoc """
+  A sample Ash TypedStruct for testing typed_struct_to_schema/1.
+  """
+
+  use Ash.TypedStruct
+
+  typed_struct do
+    field(:name, :string, allow_nil?: false, description: "The name")
+    field(:age, :integer, allow_nil?: true, description: "The age")
+    field(:active, :boolean, allow_nil?: true)
+    field(:score, :decimal, allow_nil?: true, description: "Score value")
+
+    field(:category, :atom,
+      allow_nil?: false,
+      constraints: [one_of: [:a, :b, :c]],
+      description: "The category"
+    )
+
+    field(:tags, {:array, :string}, allow_nil?: true, description: "List of tags")
+    field(:start_date, :date, allow_nil?: true, description: "Start date")
+  end
+end


### PR DESCRIPTION
Converts Ash TypedStruct modules (used for structured LLM output) to
NimbleOptions keyword list schemas that Jido actions accept directly.

This enables using Ash TypedStructs as the single source of truth for both
Elixir type validation and LLM structured output schemas.

Features:
- typed_struct_to_schema/1 converts a TypedStruct module to keyword schema
- Preserves field descriptions, required status, and defaults

Depends on #2