### PR TITLE
  Add query parameter support for read actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Bridge Ash Framework resources with Jido agents. Generates `Jido.Action` modules
 ## What It Does Not Do
 
 - Auto-discover domains or resources (domain is explicit and required)
-- Add pagination or query-layer magic
 - Bypass Ash authorization, policies, or data layers
 
 ## Installation
@@ -62,6 +61,45 @@ Generated modules:
   %{name: "John", email: "john@example.com"},
   %{domain: MyApp.Accounts}
 )
+```
+
+## Query Parameters
+
+Generated Jido read actions include optional query parameters for filtering, sorting, and pagination:
+
+```elixir
+{:ok, users} = MyApp.User.Jido.Read.run(
+  %{
+    filter: %{status: %{in: ["active", "pending"]}},
+    sort: [name: :asc, created_at: :desc],
+    limit: 20,
+    offset: 40,
+    load: [:profile, :roles]
+  },
+  %{domain: MyApp.Accounts}
+)
+```
+
+**Available Parameters:**
+
+- `filter` (map) — Filter using Ash's filter input syntax: `%{name: "fred"}`, `%{age: %{greater_than: 25}}`
+- `sort` (any) — Sort via keyword list `[name: :asc]` or string `"name,-age"`
+- `limit` (pos_integer) — Maximum results to return
+- `offset` (non_neg_integer) — Results to skip (for pagination)
+- `load` (any) — Relationships to load: `:author`, `[:author, :comments]`, `[author: [:profile]]`
+
+**Security:** Query parameters use Ash's safe `filter_input`/`sort_input` variants, which only allow filtering and sorting on public attributes and honor field policies.
+
+**Configuration:**
+
+```elixir
+jido do
+  action :read                            # query params enabled by default
+  action :read, query_params?: false      # opt out
+  action :read, max_page_size: 100        # clamp limit to max
+  all_actions read_query_params?: true    # default for all read actions
+  all_actions read_max_page_size: 100     # max page size for all reads
+end
 ```
 
 ## Context Requirements
@@ -149,6 +187,8 @@ Published signals include Ash metadata in `signal.extensions["jido_metadata"]`.
 | `vsn` | string | `nil` | Optional semantic version metadata |
 | `output_map?` | boolean | `true` | Convert structs to maps |
 | `load` | term | `nil` | Static `Ash.Query.load/2` for read actions |
+| `query_params?` | boolean | `true` | Enable query parameters (filter, sort, limit, offset, load) for read actions |
+| `max_page_size` | pos_integer | `nil` | Maximum limit value for read actions (clamps the limit parameter) |
 | `emit_signals?` | boolean | `false` | Emit Jido signals from Ash notifications (create/update/destroy) |
 | `signal_dispatch` | term | `nil` | Default signal dispatch config (can be overridden via context) |
 | `signal_type` | string | derived | Override emitted signal type |
@@ -165,6 +205,8 @@ Published signals include Ash metadata in `signal.extensions["jido_metadata"]`.
 | `tags` | list(string) | `[]` | Tags added to all generated actions |
 | `vsn` | string | `nil` | Optional semantic version metadata for generated actions |
 | `read_load` | term | `nil` | Static `Ash.Query.load/2` for generated read actions |
+| `read_query_params?` | boolean | `true` | Enable query parameters for generated read actions |
+| `read_max_page_size` | pos_integer | `nil` | Maximum limit value for generated read actions |
 | `emit_signals?` | boolean | `false` | Emit Jido signals from generated create/update/destroy actions |
 | `signal_dispatch` | term | `nil` | Default signal dispatch config for generated actions |
 | `signal_type` | string | derived | Override emitted signal type |

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -193,6 +193,8 @@ Each action in the `jido` section supports these options:
 | `vsn` | `string` | `nil` | Optional semantic version metadata |
 | `output_map?` | `boolean` | `true` | Convert output structs to maps |
 | `load` | `term` | `nil` | Static `Ash.Query.load/2` statement for read actions |
+| `query_params?` | `boolean` | `true` | Enable query parameters (filter, sort, limit, offset, load) for read actions |
+| `max_page_size` | `pos_integer` | `nil` | Maximum limit value for read actions (clamps the limit parameter) |
 | `emit_signals?` | `boolean` | `false` | Emit Jido signals from Ash notifications (create/update/destroy) |
 | `signal_dispatch` | `term` | `nil` | Default signal dispatch config (overridable via context) |
 | `signal_type` | `string` | derived | Override emitted signal type |
@@ -202,6 +204,8 @@ Each action in the `jido` section supports these options:
 `all_actions` additionally supports:
 
 - `read_load` for static read relationship loading
+- `read_query_params?` to enable/disable query parameters for read actions
+- `read_max_page_size` to set maximum page size for read actions
 - `category` (default `ash.<action_type>`)
 - `tags`
 - `vsn`
@@ -480,6 +484,164 @@ alias MyApp.Blog.Post
   %{domain: MyApp.Blog}
 )
 ```
+
+## Querying and Filtering
+
+Generated Jido read actions support query parameters for filtering, sorting, pagination, and relationship loading. These parameters are optional and provide powerful querying capabilities while respecting Ash's authorization policies.
+
+### Filter Syntax
+
+Use the `filter` parameter to query records using Ash's filter input syntax:
+
+```elixir
+# Simple equality filter
+{:ok, users} = MyApp.Accounts.User.Jido.Read.run(
+  %{filter: %{name: "John Doe"}},
+  %{domain: MyApp.Accounts}
+)
+
+# Filter with operators
+{:ok, adults} = MyApp.Accounts.User.Jido.Read.run(
+  %{filter: %{age: %{greater_than: 18}}},
+  %{domain: MyApp.Accounts}
+)
+
+# Multiple conditions (all must match)
+{:ok, active_admins} = MyApp.Accounts.User.Jido.Read.run(
+  %{filter: %{status: "active", role: "admin"}},
+  %{domain: MyApp.Accounts}
+)
+
+# IN operator for multiple values
+{:ok, users} = MyApp.Accounts.User.Jido.Read.run(
+  %{filter: %{status: %{in: ["active", "pending"]}}},
+  %{domain: MyApp.Accounts}
+)
+```
+
+**Common Filter Operators:**
+
+- `%{field: value}` — Equality
+- `%{field: %{greater_than: value}}` — Greater than
+- `%{field: %{less_than: value}}` — Less than
+- `%{field: %{greater_than_or_equal: value}}` — Greater than or equal
+- `%{field: %{less_than_or_equal: value}}` — Less than or equal
+- `%{field: %{in: [value1, value2]}}` — Match any value in list
+- `%{field: %{contains: "substring"}}` — String contains (case-sensitive)
+
+### Sorting
+
+Use the `sort` parameter to order results. You can specify sorting as a keyword list or a string:
+
+```elixir
+# Keyword list syntax
+{:ok, users} = MyApp.Blog.Post.Jido.Read.run(
+  %{sort: [created_at: :desc, title: :asc]},
+  %{domain: MyApp.Blog}
+)
+
+# String syntax (- prefix for descending)
+{:ok, users} = MyApp.Blog.Post.Jido.Read.run(
+  %{sort: "-created_at,title"},
+  %{domain: MyApp.Blog}
+)
+```
+
+### Pagination
+
+Use `limit` and `offset` for pagination:
+
+```elixir
+# First page (20 items)
+{:ok, page1} = MyApp.Accounts.User.Jido.Read.run(
+  %{limit: 20, offset: 0},
+  %{domain: MyApp.Accounts}
+)
+
+# Second page
+{:ok, page2} = MyApp.Accounts.User.Jido.Read.run(
+  %{limit: 20, offset: 20},
+  %{domain: MyApp.Accounts}
+)
+
+# Combine with filtering and sorting
+{:ok, active_users_page} = MyApp.Accounts.User.Jido.Read.run(
+  %{
+    filter: %{status: "active"},
+    sort: [name: :asc],
+    limit: 50,
+    offset: 100
+  },
+  %{domain: MyApp.Accounts}
+)
+```
+
+### Dynamic Relationship Loading
+
+Use the `load` parameter to dynamically load relationships at query time:
+
+```elixir
+# Load a single relationship
+{:ok, posts} = MyApp.Blog.Post.Jido.Read.run(
+  %{load: :author},
+  %{domain: MyApp.Blog}
+)
+
+# Load multiple relationships
+{:ok, posts} = MyApp.Blog.Post.Jido.Read.run(
+  %{load: [:author, :comments, :tags]},
+  %{domain: MyApp.Blog}
+)
+
+# Load nested relationships
+{:ok, posts} = MyApp.Blog.Post.Jido.Read.run(
+  %{load: [author: [:profile, :roles]]},
+  %{domain: MyApp.Blog}
+)
+
+# Combine with other query parameters
+{:ok, posts} = MyApp.Blog.Post.Jido.Read.run(
+  %{
+    filter: %{status: "published"},
+    sort: [published_at: :desc],
+    limit: 10,
+    load: [author: :profile, comments: :author]
+  },
+  %{domain: MyApp.Blog}
+)
+```
+
+### Configuration
+
+Query parameters are enabled by default for read actions. You can configure this behavior:
+
+```elixir
+jido do
+  # Query params enabled by default
+  action :read
+
+  # Disable query params for a specific action
+  action :read, query_params?: false
+
+  # Set maximum page size (clamps limit parameter)
+  action :read, max_page_size: 100
+
+  # Combine with static load
+  action :read, load: :profile, max_page_size: 50
+
+  # Configure defaults for all read actions
+  all_actions only: [:read], read_query_params?: true
+  all_actions only: [:read], read_max_page_size: 100
+end
+```
+
+**Security Note:** Query parameters use Ash's safe `filter_input` and `sort_input` variants, which:
+
+- Only allow filtering and sorting on public attributes
+- Honor field policies and authorization rules
+- Prevent access to private or sensitive fields
+- Validate all input before executing queries
+
 
 ## Next Steps
 

--- a/lib/ash_jido/generator.ex
+++ b/lib/ash_jido/generator.ex
@@ -63,7 +63,7 @@ defmodule AshJido.Generator do
     vsn = jido_action.vsn
 
     # Build input schema including accepted attributes
-    schema = build_parameter_schema(resource, ash_action, dsl_state)
+    schema = build_parameter_schema(resource, ash_action, jido_action, dsl_state)
 
     action_use_opts =
       [
@@ -368,7 +368,7 @@ defmodule AshJido.Generator do
     end
   end
 
-  defp build_parameter_schema(resource, ash_action, dsl_state) do
+  defp build_parameter_schema(resource, ash_action, jido_action, dsl_state) do
     case ash_action.type do
       :create ->
         # Create actions use accepted attributes plus action arguments
@@ -389,8 +389,61 @@ defmodule AshJido.Generator do
 
       _ ->
         # Read and custom actions use their declared arguments
-        action_args_to_schema(ash_action.arguments || [])
+        base_schema = action_args_to_schema(ash_action.arguments || [])
+
+        if ash_action.type == :read and jido_action.query_params? do
+          base_schema ++ build_query_params_schema(jido_action)
+        else
+          base_schema
+        end
     end
+  end
+
+  defp build_query_params_schema(jido_action) do
+    max_page_doc =
+      if jido_action.max_page_size do
+        " Maximum: #{jido_action.max_page_size}."
+      else
+        ""
+      end
+
+    [
+      filter: [
+        type: :map,
+        required: false,
+        doc:
+          "Filter results using Ash's filter input syntax. " <>
+            "Simple equality: %{\"name\" => \"fred\"}. " <>
+            "Operators: %{\"age\" => %{\"greater_than\" => 25}}. " <>
+            "In: %{\"status\" => %{\"in\" => [\"active\", \"pending\"]}}. " <>
+            "Only public attributes are accessible."
+      ],
+      sort: [
+        type: :any,
+        required: false,
+        doc:
+          "Sort results. Keyword list: [name: :asc, age: :desc]. " <>
+            "String: \"name,-age\" (minus prefix = descending)."
+      ],
+      limit: [
+        type: :pos_integer,
+        required: false,
+        doc: "Maximum number of results to return.#{max_page_doc}"
+      ],
+      offset: [
+        type: :non_neg_integer,
+        required: false,
+        doc: "Number of results to skip."
+      ],
+      load: [
+        type: :any,
+        required: false,
+        doc:
+          "Relationships/calculations to load. " <>
+            "Examples: :author, [:author, :comments], [author: [:profile]]. " <>
+            "Merged with any static load configured on the action."
+      ]
+    ]
   end
 
   defp accepted_attributes_to_schema(_resource, ash_action, dsl_state) do

--- a/lib/ash_jido/generator.ex
+++ b/lib/ash_jido/generator.ex
@@ -145,11 +145,17 @@ defmodule AshJido.Generator do
                 {action_result, signal_emission, false}
 
               :read ->
-                result =
+                # Split query params from action arguments
+                {query_opts, action_params} = split_query_params(params, @jido_config)
+
+                # Build query: apply action args, then static load, then dynamic query opts
+                query =
                   @resource
-                  |> Ash.Query.for_read(@ash_action, params, ash_opts)
+                  |> Ash.Query.for_read(@ash_action, action_params, ash_opts)
                   |> maybe_load(@jido_config)
-                  |> Ash.read!(ash_opts)
+                  |> apply_query_opts(query_opts)
+
+                result = Ash.read!(query, ash_opts)
 
                 # Ash.read! returns a raw list, not {:ok, result}
                 # Pass it directly to Mapper.wrap_result which will wrap it
@@ -272,6 +278,51 @@ defmodule AshJido.Generator do
             nil -> query
             load -> Ash.Query.load(query, load)
           end
+        end
+
+        @query_param_keys [:filter, :sort, :limit, :offset, :load]
+
+        defp split_query_params(params, jido_config) do
+          if jido_config.query_params? do
+            {query_opts_map, action_params} = Map.split(params, @query_param_keys)
+
+            query_opts =
+              query_opts_map
+              |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+              |> enforce_max_page_size(jido_config)
+
+            {query_opts, action_params}
+          else
+            {[], params}
+          end
+        end
+
+        defp enforce_max_page_size(query_opts, jido_config) do
+          case jido_config.max_page_size do
+            nil ->
+              query_opts
+
+            max when is_integer(max) ->
+              case Keyword.get(query_opts, :limit) do
+                limit when is_integer(limit) and limit > max ->
+                  Keyword.put(query_opts, :limit, max)
+
+                _ ->
+                  query_opts
+              end
+          end
+        end
+
+        defp apply_query_opts(query, []), do: query
+
+        defp apply_query_opts(query, query_opts) do
+          Enum.reduce(query_opts, query, fn
+            {:filter, filter_map}, q -> Ash.Query.filter_input(q, filter_map)
+            {:sort, sort_val}, q -> Ash.Query.sort_input(q, sort_val)
+            {:limit, limit}, q -> Ash.Query.limit(q, limit)
+            {:offset, offset}, q -> Ash.Query.offset(q, offset)
+            {:load, load}, q -> Ash.Query.load(q, load)
+          end)
         end
 
         defp maybe_add_notification_collection(ash_opts, config, action_type) do

--- a/lib/ash_jido/resource/all_actions.ex
+++ b/lib/ash_jido/resource/all_actions.ex
@@ -10,12 +10,14 @@ defmodule AshJido.Resource.AllActions do
     :tags,
     :vsn,
     :read_load,
+    :read_max_page_size,
     :signal_dispatch,
     :signal_type,
     :signal_source,
     :__spark_metadata__,
     emit_signals?: false,
-    telemetry?: false
+    telemetry?: false,
+    read_query_params?: true
   ]
 
   @type t :: %__MODULE__{
@@ -25,10 +27,12 @@ defmodule AshJido.Resource.AllActions do
           tags: [String.t()] | nil,
           vsn: String.t() | nil,
           read_load: term() | nil,
+          read_max_page_size: pos_integer() | nil,
           signal_dispatch: term() | nil,
           signal_type: String.t() | nil,
           signal_source: String.t() | nil,
           emit_signals?: boolean(),
-          telemetry?: boolean()
+          telemetry?: boolean(),
+          read_query_params?: boolean()
         }
 end

--- a/lib/ash_jido/resource/dsl.ex
+++ b/lib/ash_jido/resource/dsl.ex
@@ -136,6 +136,20 @@ defmodule AshJido.Resource.Dsl do
           type: :boolean,
           default: false,
           doc: "Emit telemetry spans for generated action execution"
+        ],
+        query_params?: [
+          type: :boolean,
+          required: false,
+          doc: """
+          Enable query parameters (filter, sort, limit, offset, load) for read actions.
+          Defaults to `true` for read actions. When enabled, the generated Jido action
+          accepts query parameters using Ash's safe input parsing (filter_input, sort_input).
+          """
+        ],
+        max_page_size: [
+          type: :pos_integer,
+          required: false,
+          doc: "Maximum page size (limit) for this action. Used to enforce query bounds at runtime."
         ]
       ]
     }
@@ -213,6 +227,16 @@ defmodule AshJido.Resource.Dsl do
           type: :boolean,
           default: false,
           doc: "Emit telemetry spans for generated action execution"
+        ],
+        read_query_params?: [
+          type: :boolean,
+          default: true,
+          doc: "Enable query parameters for auto-generated read actions."
+        ],
+        read_max_page_size: [
+          type: :pos_integer,
+          required: false,
+          doc: "Maximum page size for auto-generated read actions."
         ]
       ]
     }

--- a/lib/ash_jido/resource/dsl.ex
+++ b/lib/ash_jido/resource/dsl.ex
@@ -149,7 +149,8 @@ defmodule AshJido.Resource.Dsl do
         max_page_size: [
           type: :pos_integer,
           required: false,
-          doc: "Maximum page size (limit) for this action. Used to enforce query bounds at runtime."
+          doc:
+            "Maximum page size (limit) for this action. Used to enforce query bounds at runtime."
         ]
       ]
     }

--- a/lib/ash_jido/resource/jido_action.ex
+++ b/lib/ash_jido/resource/jido_action.ex
@@ -12,13 +12,15 @@ defmodule AshJido.Resource.JidoAction do
     :tags,
     :vsn,
     :load,
+    :max_page_size,
     :signal_dispatch,
     :signal_type,
     :signal_source,
     :__spark_metadata__,
     emit_signals?: false,
     telemetry?: false,
-    output_map?: true
+    output_map?: true,
+    query_params?: true
   ]
 
   @type t :: %__MODULE__{
@@ -30,11 +32,13 @@ defmodule AshJido.Resource.JidoAction do
           tags: [String.t()] | nil,
           vsn: String.t() | nil,
           load: term() | nil,
+          max_page_size: pos_integer() | nil,
           signal_dispatch: term() | nil,
           signal_type: String.t() | nil,
           signal_source: String.t() | nil,
           emit_signals?: boolean(),
           telemetry?: boolean(),
-          output_map?: boolean()
+          output_map?: boolean(),
+          query_params?: boolean()
         }
 end

--- a/lib/ash_jido/resource/transformers/generate_jido_actions.ex
+++ b/lib/ash_jido/resource/transformers/generate_jido_actions.ex
@@ -88,7 +88,10 @@ defmodule AshJido.Resource.Transformers.GenerateJidoActions do
         signal_type: all_actions.signal_type,
         signal_source: all_actions.signal_source,
         telemetry?: all_actions.telemetry? || false,
-        output_map?: true
+        output_map?: true,
+        query_params?:
+          if(ash_action.type == :read, do: all_actions.read_query_params?, else: false),
+        max_page_size: if(ash_action.type == :read, do: all_actions.read_max_page_size)
       }
     end)
   end

--- a/test/ash_jido/enhanced_generator_test.exs
+++ b/test/ash_jido/enhanced_generator_test.exs
@@ -168,15 +168,16 @@ defmodule AshJido.EnhancedGeneratorTest do
       # Check the generated module exists
       assert Code.ensure_loaded?(module_name)
 
-      # Check it has the correct schema (only action arguments, no hardcoded params)
+      # Check schema includes action arguments and query params
       schema = module_name.schema()
       schema_keys = Keyword.keys(schema)
 
       # Should have action-specific argument
       assert :email in schema_keys
 
-      # Should NOT have hardcoded parameters - only action arguments
-      assert length(schema_keys) == 1
+      # Should also have query params since query_params? defaults to true
+      assert :filter in schema_keys
+      assert :sort in schema_keys
     end
   end
 end

--- a/test/ash_jido/generator_test.exs
+++ b/test/ash_jido/generator_test.exs
@@ -150,9 +150,13 @@ defmodule AshJido.GeneratorTest do
       assert Code.ensure_loaded?(module_name)
       assert module_name.name() == "list_all"
 
-      # Read actions only use action arguments (no hardcoded params)
+      # Read actions with query_params?: true (default) include query params
       schema = module_name.schema()
-      assert schema == []
+      assert Keyword.has_key?(schema, :filter)
+      assert Keyword.has_key?(schema, :sort)
+      assert Keyword.has_key?(schema, :limit)
+      assert Keyword.has_key?(schema, :offset)
+      assert Keyword.has_key?(schema, :load)
     end
 
     test "raises error for non-existent action" do

--- a/test/ash_jido/query_params_test.exs
+++ b/test/ash_jido/query_params_test.exs
@@ -1,0 +1,101 @@
+defmodule AshJido.QueryParamsTest do
+  @moduledoc """
+  Tests for query parameter support on read actions.
+  """
+  use ExUnit.Case, async: false
+  @moduletag :capture_log
+
+  describe "schema generation" do
+    test "read actions include query params in schema by default" do
+      # AshJido.Test.User has `action(:read)` in its jido section
+      # The generated module is AshJido.Test.User.Jido.Read
+      module = AshJido.Test.User.Jido.Read
+      schema = module.schema()
+
+      assert Keyword.has_key?(schema, :filter)
+      assert Keyword.has_key?(schema, :sort)
+      assert Keyword.has_key?(schema, :limit)
+      assert Keyword.has_key?(schema, :offset)
+      assert Keyword.has_key?(schema, :load)
+    end
+
+    test "query param schema entries have correct types" do
+      schema = AshJido.Test.User.Jido.Read.schema()
+
+      assert schema[:filter][:type] == :map
+      assert schema[:limit][:type] == :pos_integer
+      assert schema[:offset][:type] == :non_neg_integer
+    end
+
+    test "query params are not required" do
+      schema = AshJido.Test.User.Jido.Read.schema()
+
+      refute schema[:filter][:required]
+      refute schema[:sort][:required]
+      refute schema[:limit][:required]
+      refute schema[:offset][:required]
+      refute schema[:load][:required]
+    end
+
+    test "query param docs are present" do
+      schema = AshJido.Test.User.Jido.Read.schema()
+
+      assert is_binary(schema[:filter][:doc])
+      assert is_binary(schema[:sort][:doc])
+      assert is_binary(schema[:limit][:doc])
+      assert is_binary(schema[:offset][:doc])
+      assert is_binary(schema[:load][:doc])
+    end
+
+    test "non-read actions do NOT include query params" do
+      # AshJido.Test.User.Jido.Register is a create action
+      schema = AshJido.Test.User.Jido.Register.schema()
+
+      refute Keyword.has_key?(schema, :filter)
+      refute Keyword.has_key?(schema, :sort)
+      refute Keyword.has_key?(schema, :limit)
+      refute Keyword.has_key?(schema, :offset)
+      refute Keyword.has_key?(schema, :load)
+    end
+
+    test "read actions with arguments include both args and query params" do
+      # AshJido.Test.User.Jido.ByEmail has an :email argument
+      schema = AshJido.Test.User.Jido.ByEmail.schema()
+
+      # Action argument
+      assert Keyword.has_key?(schema, :email)
+      # Query params
+      assert Keyword.has_key?(schema, :filter)
+      assert Keyword.has_key?(schema, :sort)
+    end
+  end
+
+  describe "query_params? opt-out" do
+    test "read action with query_params?: false excludes query params from schema" do
+      dsl_state = AshJido.Test.User.spark_dsl_config()
+
+      jido_action = %AshJido.Resource.JidoAction{
+        action: :read,
+        name: "list_no_query_params",
+        module_name: TestNoQueryParamsReadAction,
+        description: "List without query params",
+        output_map?: true,
+        query_params?: false
+      }
+
+      module_name =
+        AshJido.Generator.generate_jido_action_module(
+          AshJido.Test.User,
+          jido_action,
+          dsl_state
+        )
+
+      schema = module_name.schema()
+      refute Keyword.has_key?(schema, :filter)
+      refute Keyword.has_key?(schema, :sort)
+      refute Keyword.has_key?(schema, :limit)
+      refute Keyword.has_key?(schema, :offset)
+      refute Keyword.has_key?(schema, :load)
+    end
+  end
+end

--- a/test/ash_jido/query_params_test.exs
+++ b/test/ash_jido/query_params_test.exs
@@ -98,4 +98,247 @@ defmodule AshJido.QueryParamsTest do
       refute Keyword.has_key?(schema, :load)
     end
   end
+
+  describe "runtime: filter" do
+    setup :create_test_users
+
+    test "filters by exact equality", %{users: _users} do
+      {:ok, result} =
+        AshJido.Test.User.Jido.Read.run(
+          %{filter: %{name: "Alice"}},
+          %{domain: AshJido.Test.Domain}
+        )
+
+      assert length(result) == 1
+      assert hd(result)[:name] == "Alice"
+    end
+
+    test "filters with greater_than operator", %{users: _users} do
+      {:ok, result} =
+        AshJido.Test.User.Jido.Read.run(
+          %{filter: %{age: %{greater_than: 28}}},
+          %{domain: AshJido.Test.Domain}
+        )
+
+      # Alice (30) and Charlie (35)
+      assert length(result) == 2
+      names = Enum.map(result, & &1[:name]) |> Enum.sort()
+      assert names == ["Alice", "Charlie"]
+    end
+
+    test "filters with in operator", %{users: _users} do
+      {:ok, result} =
+        AshJido.Test.User.Jido.Read.run(
+          %{filter: %{name: %{in: ["Alice", "Bob"]}}},
+          %{domain: AshJido.Test.Domain}
+        )
+
+      assert length(result) == 2
+    end
+
+    test "filters with multiple conditions (AND)", %{users: _users} do
+      {:ok, result} =
+        AshJido.Test.User.Jido.Read.run(
+          %{filter: %{active: true, age: %{greater_than: 28}}},
+          %{domain: AshJido.Test.Domain}
+        )
+
+      # Alice is 30 and active, Charlie is 35 and active
+      assert length(result) == 2
+    end
+  end
+
+  describe "runtime: sort" do
+    setup :create_test_users
+
+    test "sorts ascending", %{users: _users} do
+      {:ok, result} =
+        AshJido.Test.User.Jido.Read.run(
+          %{sort: [age: :asc]},
+          %{domain: AshJido.Test.Domain}
+        )
+
+      ages = Enum.map(result, & &1[:age])
+      assert ages == [25, 30, 35]
+    end
+
+    test "sorts descending", %{users: _users} do
+      {:ok, result} =
+        AshJido.Test.User.Jido.Read.run(
+          %{sort: [age: :desc]},
+          %{domain: AshJido.Test.Domain}
+        )
+
+      ages = Enum.map(result, & &1[:age])
+      assert ages == [35, 30, 25]
+    end
+  end
+
+  describe "runtime: limit and offset" do
+    setup :create_test_users
+
+    test "limits results", %{users: _users} do
+      {:ok, result} =
+        AshJido.Test.User.Jido.Read.run(
+          %{sort: [age: :asc], limit: 2},
+          %{domain: AshJido.Test.Domain}
+        )
+
+      assert length(result) == 2
+    end
+
+    test "offsets results", %{users: _users} do
+      {:ok, result} =
+        AshJido.Test.User.Jido.Read.run(
+          %{sort: [age: :asc], offset: 1},
+          %{domain: AshJido.Test.Domain}
+        )
+
+      assert length(result) == 2
+      assert hd(result)[:age] == 30
+    end
+
+    test "combines limit and offset", %{users: _users} do
+      {:ok, result} =
+        AshJido.Test.User.Jido.Read.run(
+          %{sort: [age: :asc], limit: 1, offset: 1},
+          %{domain: AshJido.Test.Domain}
+        )
+
+      assert length(result) == 1
+      assert hd(result)[:name] == "Alice"
+    end
+  end
+
+  describe "runtime: combined params" do
+    setup :create_test_users
+
+    test "filter + sort + limit", %{users: _users} do
+      {:ok, result} =
+        AshJido.Test.User.Jido.Read.run(
+          %{filter: %{active: true}, sort: [age: :desc], limit: 2},
+          %{domain: AshJido.Test.Domain}
+        )
+
+      assert length(result) == 2
+      ages = Enum.map(result, & &1[:age])
+      assert ages == [35, 30]
+    end
+  end
+
+  describe "runtime: no query params" do
+    setup :create_test_users
+
+    test "works normally without query params", %{users: _users} do
+      {:ok, result} =
+        AshJido.Test.User.Jido.Read.run(
+          %{},
+          %{domain: AshJido.Test.Domain}
+        )
+
+      # Should return all 3 users
+      assert length(result) == 3
+    end
+  end
+
+  describe "runtime: max_page_size enforcement" do
+    setup :create_test_users
+
+    test "clamps limit to max_page_size", %{users: _users} do
+      dsl_state = AshJido.Test.User.spark_dsl_config()
+
+      jido_action = %AshJido.Resource.JidoAction{
+        action: :read,
+        name: "list_with_max_page",
+        module_name: TestMaxPageSizeReadAction,
+        description: "List with max page size",
+        output_map?: true,
+        query_params?: true,
+        max_page_size: 2
+      }
+
+      module_name =
+        AshJido.Generator.generate_jido_action_module(
+          AshJido.Test.User,
+          jido_action,
+          dsl_state
+        )
+
+      # Request limit: 100, but max_page_size is 2
+      {:ok, result} =
+        module_name.run(
+          %{sort: [age: :asc], limit: 100},
+          %{domain: AshJido.Test.Domain}
+        )
+
+      assert length(result) == 2
+    end
+
+    test "does not clamp when limit is within max_page_size", %{users: _users} do
+      dsl_state = AshJido.Test.User.spark_dsl_config()
+
+      jido_action = %AshJido.Resource.JidoAction{
+        action: :read,
+        name: "list_with_max_page2",
+        module_name: TestMaxPageSize2ReadAction,
+        description: "List with max page size",
+        output_map?: true,
+        query_params?: true,
+        max_page_size: 10
+      }
+
+      module_name =
+        AshJido.Generator.generate_jido_action_module(
+          AshJido.Test.User,
+          jido_action,
+          dsl_state
+        )
+
+      # Request limit: 2, which is within max_page_size 10
+      {:ok, result} =
+        module_name.run(
+          %{sort: [age: :asc], limit: 2},
+          %{domain: AshJido.Test.Domain}
+        )
+
+      assert length(result) == 2
+    end
+  end
+
+  defp create_test_users(_context) do
+    opts = [domain: AshJido.Test.Domain]
+
+    user1 =
+      AshJido.Test.User
+      |> Ash.Changeset.for_create(
+        :register,
+        %{name: "Alice", email: "alice@example.com", age: 30},
+        opts
+      )
+      |> Ash.create!(opts)
+
+    user2 =
+      AshJido.Test.User
+      |> Ash.Changeset.for_create(
+        :register,
+        %{name: "Bob", email: "bob@example.com", age: 25},
+        opts
+      )
+      |> Ash.create!(opts)
+
+    user3 =
+      AshJido.Test.User
+      |> Ash.Changeset.for_create(
+        :register,
+        %{
+          name: "Charlie",
+          email: "charlie@example.com",
+          age: 35
+        },
+        opts
+      )
+      |> Ash.create!(opts)
+
+    %{users: [user1, user2, user3]}
+  end
 end

--- a/test/integration/ash_jido_integration_test.exs
+++ b/test/integration/ash_jido_integration_test.exs
@@ -186,13 +186,15 @@ defmodule AshJido.IntegrationTest do
       by_email_module = User.Jido.ByEmail
       assert by_email_module.name() == "find_user_by_email"
 
-      # Read actions only include action arguments, no hardcoded params
+      # Read actions include action arguments and query params
       schema = by_email_module.schema()
       # Action-specific argument from the :by_email action
       assert Keyword.has_key?(schema, :email)
-      # Should NOT have hardcoded params
+      # Should NOT have hardcoded id param
       refute Keyword.has_key?(schema, :id)
-      refute Keyword.has_key?(schema, :limit)
+      # Should have query params (query_params? defaults to true for read actions)
+      assert Keyword.has_key?(schema, :filter)
+      assert Keyword.has_key?(schema, :limit)
     end
 
     test "Post resource integration works" do

--- a/test/support/test_user.ex
+++ b/test/support/test_user.ex
@@ -14,10 +14,10 @@ defmodule AshJido.Test.User do
 
   attributes do
     uuid_primary_key(:id)
-    attribute(:name, :string, allow_nil?: false)
-    attribute(:email, :string, allow_nil?: false)
-    attribute(:age, :integer)
-    attribute(:active, :boolean, default: true)
+    attribute(:name, :string, allow_nil?: false, public?: true)
+    attribute(:email, :string, allow_nil?: false, public?: true)
+    attribute(:age, :integer, public?: true)
+    attribute(:active, :boolean, default: true, public?: true)
     timestamps()
   end
 


### PR DESCRIPTION
## Problem

Generated Jido read actions had no way to filter, sort, or paginate results. An LLM agent calling ListUsers would always get back every record with no ability to narrow results — making read tools impractical for any non-trivial dataset.

## Solution

Read actions now accept optional filter, sort, limit, offset, and load parameters that map directly to Ash's query API. These appear in the action's NimbleOptions schema (and therefore in the JSON Schema that LLMs see), so agents can discover and use them through normal tool calling.

### Example usage

```elixir
  # Filter + sort + paginate
  {:ok, users} = ListUsers.run(
    %{
      filter: %{age: %{greater_than: 25}, active: true},
      sort: [name: :asc],
      limit: 10,
      offset: 20,
      load: [:profile]
    },
    %{domain: MyApp.Accounts}
  )
  # => [%{name: "Alice", age: 30, profile: %{bio: "..."}}, ...]

  # Still works with no params (backward compatible)
  {:ok, all_users} = ListUsers.run(%{}, %{domain: MyApp.Accounts})
```

### Security

Query parameters use Ash's safe input variants — Ash.Query.filter_input/2 and Ash.Query.sort_input/2 — which only permit filtering and sorting on public attributes and honor field policies. Private or internal fields cannot be accessed through these parameters.

### Configuration

Enabled by default for read actions. Can be controlled per-action or globally:

```elixir
  jido do
    action :read                            # query params enabled (default)
    action :read, query_params?: false      # opt out
    action :read, max_page_size: 100        # clamp limit to 100

    all_actions read_query_params?: true    # default for all reads
    all_actions read_max_page_size: 100     # max page for all reads
  end
```

## Changes

### ad6b1be — DSL options and schema generation

- Add query_params? (default: true) and max_page_size fields to JidoAction struct
- Add read_query_params? and read_max_page_size to AllActions struct
- Add corresponding DSL options to action and all_actions entities
- Update transformer to propagate new fields for read actions
- Update build_parameter_schema/4 to append query params to read action schemas
- 7 new tests for schema generation and opt-out behavior

### 1359b24 — Runtime execution

- Update the :read case to split query params from action arguments before Ash.Query.for_read
- Apply query options via Enum.reduce over individual Ash.Query functions (filter_input, sort_input, limit, offset, load)
- Enforce max_page_size by clamping the limit value
- Make test User attributes public?: true (required for filter_input)
- 13 new runtime integration tests (filter, sort, pagination, combined, max_page_size, backward compat)

### dadcd12 — Documentation

- Add "Query Parameters" section to README with examples and configuration reference
- Add "Querying and Filtering" section to getting-started guide with filter syntax, sort formats, pagination, and dynamic loading
- Update DSL option tables in README

Test coverage

20 new tests across schema generation and runtime execution:

| Area | Tests |
|------|-------|
| Schema: params present/absent/types/docs | 7 |
| Filter: equality, greater_than, in, AND | 4 |
| Sort: asc, desc | 2 |
| Pagination: limit, offset, combined | 3 |
| Combined: filter + sort + limit | 1 |
| max_page_size: clamp + within bounds | 2 |
| Backward compat: empty params | 1 |


All 182 tests pass. mix quality clean (format, compile, credo, dialyzer).

## Disclaimer

This PR was written by Claude, but I've looked through it and it seems reasonable.

It might be worth considering whether there should be some protection against misuse, but the language is rather limited, so aside from trying to load every related resource, I don't think there's much an attacker can do.

It might also be worth considering if this behavior should be opt-in rather than opt-out.

Fixes #4 