### PR TITLE
feat: support {:array, Ash.Type.Atom} with one_of constraints in TypeMapper

### DIFF
--- a/lib/ash_jido/type_mapper.ex
+++ b/lib/ash_jido/type_mapper.ex
@@ -112,5 +112,20 @@ defmodule AshJido.TypeMapper do
     end
   end
 
+  # Converts {:array, Ash.Type.Atom} with items one_of constraints to {:list, {:in, string_values}}
+  defp maybe_add_enum_constraint(opts, %{type: {:array, Ash.Type.Atom}, constraints: constraints})
+       when is_list(constraints) do
+    items = Keyword.get(constraints, :items, [])
+
+    case Keyword.get(items, :one_of) do
+      values when is_list(values) and values != [] ->
+        string_values = Enum.map(values, &to_string/1)
+        Keyword.put(opts, :type, {:list, {:in, string_values}})
+
+      _ ->
+        opts
+    end
+  end
+
   defp maybe_add_enum_constraint(opts, _field_config), do: opts
 end

--- a/test/ash_jido/type_mapper_test.exs
+++ b/test/ash_jido/type_mapper_test.exs
@@ -152,6 +152,22 @@ defmodule AshJido.TypeMapperTest do
       result = TypeMapper.ash_type_to_nimble_options(Ash.Type.Atom, options)
       assert result[:type] == :atom
     end
+
+    test "converts {:array, Ash.Type.Atom} with items one_of to {:list, {:in, string_values}}" do
+      options = %{
+        type: {:array, Ash.Type.Atom},
+        constraints: [items: [one_of: [:individual_policy, :multi_policy, :overview]]]
+      }
+
+      result = TypeMapper.ash_type_to_nimble_options({:array, Ash.Type.Atom}, options)
+      assert result[:type] == {:list, {:in, ["individual_policy", "multi_policy", "overview"]}}
+    end
+
+    test "leaves {:array, Ash.Type.Atom} as {:list, :atom} when no items one_of constraint" do
+      options = %{type: {:array, Ash.Type.Atom}, constraints: []}
+      result = TypeMapper.ash_type_to_nimble_options({:array, Ash.Type.Atom}, options)
+      assert result[:type] == {:list, :atom}
+    end
   end
 
   describe "edge cases and complex scenarios" do
@@ -247,6 +263,14 @@ defmodule AshJido.TypeMapperTest do
 
       # Atom field with one_of constraint should be converted to {:in, string_values}
       assert schema[:category][:type] == {:in, ["a", "b", "c"]}
+    end
+
+    test "converts array of atoms with one_of to {:list, {:in, values}}" do
+      schema = TypeMapper.typed_struct_to_schema(SampleExtractionResult)
+
+      assert schema[:roles][:type] == {:list, {:in, ["admin", "editor", "viewer"]}}
+      assert schema[:roles][:required] == true
+      assert schema[:roles][:doc] == "User roles"
     end
 
     test "handles fields without descriptions" do

--- a/test/support/sample_extraction_result.ex
+++ b/test/support/sample_extraction_result.ex
@@ -18,6 +18,13 @@ defmodule AshJido.Test.SampleExtractionResult do
     )
 
     field(:tags, {:array, :string}, allow_nil?: true, description: "List of tags")
+
+    field(:roles, {:array, :atom},
+      allow_nil?: false,
+      constraints: [items: [one_of: [:admin, :editor, :viewer]]],
+      description: "User roles"
+    )
+
     field(:start_date, :date, allow_nil?: true, description: "Start date")
   end
 end


### PR DESCRIPTION
Adds a new clause to `maybe_add_enum_constraint/2` that handles `{:array, Ash.Type.Atom}` with nested `items: [one_of: [...]]` constraints.

Previously, only plain `Ash.Type.Atom` fields with `one_of` were converted to `{:in, string_values}`. Array-of-atom fields like:

```elixir
field :document_types, {:array, :atom},
  constraints: [items: [one_of: [:individual_policy, :multi_policy, :overview]]]
```

Would produce `{:list, :atom}` instead of `{:list, {:in, ["individual_policy", "multi_policy", "overview"]}}`.

This matters for structured LLM output schemas — without the enum constraint, the JSON schema lacks the allowed values and the model can return arbitrary strings.