### PR TITLE
fix: wrap non-map action results to satisfy Jido.Exec output validation

### DIFF
--- a/lib/ash_jido/mapper.ex
+++ b/lib/ash_jido/mapper.ex
@@ -64,7 +64,12 @@ defmodule AshJido.Mapper do
   end
 
   defp maybe_convert_to_maps(data, %{output_map?: false}), do: data
-  defp maybe_convert_to_maps(data, _config), do: convert_to_maps(data)
+
+  defp maybe_convert_to_maps(data, _config) do
+    data
+    |> convert_to_maps()
+    |> ensure_map_output()
+  end
 
   defp convert_to_maps(data) when is_list(data) do
     Enum.map(data, &convert_to_maps/1)
@@ -78,6 +83,7 @@ defmodule AshJido.Mapper do
     end
   end
 
+  # Pass through maps and primitives unchanged during recursive conversion
   defp convert_to_maps(data), do: data
 
   defp is_ash_resource?(struct) do
@@ -90,4 +96,10 @@ defmodule AshJido.Mapper do
     |> Map.drop(@ash_meta_keys)
     |> Enum.into(%{}, fn {k, v} -> {k, convert_to_maps(v)} end)
   end
+
+  # Ensures the final output is a map to satisfy Jido.Exec validation
+  # Maps (including structs) and lists pass through, but primitives get wrapped
+  defp ensure_map_output(data) when is_map(data), do: data
+  defp ensure_map_output(data) when is_list(data), do: data
+  defp ensure_map_output(data), do: %{result: data}
 end

--- a/lib/ash_jido/mapper.ex
+++ b/lib/ash_jido/mapper.ex
@@ -63,7 +63,7 @@ defmodule AshJido.Mapper do
     end
   end
 
-  defp maybe_convert_to_maps(data, %{output_map?: false}), do: data
+  defp maybe_convert_to_maps(data, %{output_map?: false}), do: ensure_map_output(data)
 
   defp maybe_convert_to_maps(data, _config) do
     data
@@ -97,9 +97,9 @@ defmodule AshJido.Mapper do
     |> Enum.into(%{}, fn {k, v} -> {k, convert_to_maps(v)} end)
   end
 
-  # Ensures the final output is a map to satisfy Jido.Exec validation
-  # Maps (including structs) and lists pass through, but primitives get wrapped
+  # Ensures the final output is a map to satisfy Jido.Exec output validation.
+  # Maps (including structs) pass through; all other values (lists, scalars,
+  # nil) are wrapped in %{result: value}.
   defp ensure_map_output(data) when is_map(data), do: data
-  defp ensure_map_output(data) when is_list(data), do: data
   defp ensure_map_output(data), do: %{result: data}
 end

--- a/test/ash_jido/exec_integration_test.exs
+++ b/test/ash_jido/exec_integration_test.exs
@@ -1,0 +1,246 @@
+defmodule AshJido.ExecIntegrationTest do
+  @moduledoc """
+  Integration tests exercising generated AshJido actions through Jido.Exec.run/3.
+
+  These tests verify that AshJido-generated actions produce outputs compatible
+  with Jido.Exec's validation pipeline, which calls Map.split/2 on results
+  and therefore requires map outputs.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  # ── Test resources ──────────────────────────────────────────────────
+
+  defmodule ScalarResource do
+    use Ash.Resource,
+      domain: nil,
+      extensions: [AshJido],
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:name, :string, allow_nil?: false)
+    end
+
+    actions do
+      defaults([:read])
+
+      action :greet do
+        description("Returns a greeting string")
+        returns(:string)
+        argument(:name, :string, allow_nil?: false)
+
+        run(fn input, _context ->
+          {:ok, "Hello, #{input.arguments.name}!"}
+        end)
+      end
+
+      action :count do
+        description("Returns an integer count")
+        returns(:integer)
+
+        run(fn _input, _context ->
+          {:ok, 42}
+        end)
+      end
+
+      action :check do
+        description("Returns a boolean")
+        returns(:boolean)
+
+        run(fn _input, _context ->
+          {:ok, true}
+        end)
+      end
+
+      action :status do
+        description("Returns an atom")
+        returns(:atom)
+
+        run(fn _input, _context ->
+          {:ok, :active}
+        end)
+      end
+
+      action :nothing do
+        description("A void action that returns nothing")
+
+        run(fn _input, _context ->
+          :ok
+        end)
+      end
+
+      action :get_tags do
+        description("Returns a list of strings")
+        returns({:array, :string})
+
+        run(fn _input, _context ->
+          {:ok, ["alpha", "beta", "gamma"]}
+        end)
+      end
+
+      action :get_map do
+        description("Returns a plain map")
+        returns(:map)
+
+        run(fn _input, _context ->
+          {:ok, %{key: "value", count: 1}}
+        end)
+      end
+    end
+
+    jido do
+      action(:greet, name: "greet_user")
+      action(:count, name: "count_items")
+      action(:check, name: "check_status")
+      action(:status, name: "get_status")
+      action(:nothing, name: "get_nothing")
+      action(:get_tags, name: "list_tags")
+      action(:get_map, name: "get_map_data")
+    end
+  end
+
+  defmodule ScalarRawResource do
+    @moduledoc "Same actions but with output_map?: false"
+    use Ash.Resource,
+      domain: nil,
+      extensions: [AshJido],
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:name, :string, allow_nil?: false)
+    end
+
+    actions do
+      defaults([:read])
+
+      action :greet do
+        description("Returns a greeting string")
+        returns(:string)
+        argument(:name, :string, allow_nil?: false)
+
+        run(fn input, _context ->
+          {:ok, "Hello, #{input.arguments.name}!"}
+        end)
+      end
+
+      action :get_tags do
+        description("Returns a list of strings")
+        returns({:array, :string})
+
+        run(fn _input, _context ->
+          {:ok, ["alpha", "beta", "gamma"]}
+        end)
+      end
+    end
+
+    jido do
+      action(:greet, name: "greet_user_raw", output_map?: false)
+      action(:get_tags, name: "list_tags_raw", output_map?: false)
+    end
+  end
+
+  defmodule ExecTestDomain do
+    use Ash.Domain, validate_config_inclusion?: false
+
+    resources do
+      resource(ScalarResource)
+      resource(ScalarRawResource)
+    end
+  end
+
+  # ── Tests: output_map?: true (default) ─────────────────────────────
+
+  describe "Jido.Exec.run/3 with output_map?: true (default)" do
+    test "scalar string result passes through Jido.Exec validation" do
+      action_module = ScalarResource.Jido.Greet
+
+      result =
+        Jido.Exec.run(action_module, %{name: "World"}, %{domain: ExecTestDomain})
+
+      assert {:ok, %{result: "Hello, World!"}} = result
+    end
+
+    test "scalar integer result passes through Jido.Exec validation" do
+      action_module = ScalarResource.Jido.Count
+
+      result = Jido.Exec.run(action_module, %{}, %{domain: ExecTestDomain})
+
+      assert {:ok, %{result: 42}} = result
+    end
+
+    test "scalar boolean result passes through Jido.Exec validation" do
+      action_module = ScalarResource.Jido.Check
+
+      result = Jido.Exec.run(action_module, %{}, %{domain: ExecTestDomain})
+
+      assert {:ok, %{result: true}} = result
+    end
+
+    test "scalar atom result passes through Jido.Exec validation" do
+      action_module = ScalarResource.Jido.Status
+
+      result = Jido.Exec.run(action_module, %{}, %{domain: ExecTestDomain})
+
+      assert {:ok, %{result: :active}} = result
+    end
+
+    test "void action result passes through Jido.Exec validation" do
+      action_module = ScalarResource.Jido.Nothing
+
+      result = Jido.Exec.run(action_module, %{}, %{domain: ExecTestDomain})
+
+      # Ash.run_action! returns :ok for void actions,
+      # generator wraps as {:ok, :ok}, mapper wraps atom as %{result: :ok}
+      assert {:ok, %{result: :ok}} = result
+    end
+
+    test "list result passes through Jido.Exec validation" do
+      action_module = ScalarResource.Jido.GetTags
+
+      result = Jido.Exec.run(action_module, %{}, %{domain: ExecTestDomain})
+
+      assert {:ok, %{result: ["alpha", "beta", "gamma"]}} = result
+    end
+
+    test "map result passes through Jido.Exec validation" do
+      action_module = ScalarResource.Jido.GetMap
+
+      result = Jido.Exec.run(action_module, %{}, %{domain: ExecTestDomain})
+
+      assert {:ok, %{key: "value", count: 1}} = result
+    end
+  end
+
+  # ── Tests: output_map?: false ──────────────────────────────────────
+
+  describe "Jido.Exec.run/3 with output_map?: false" do
+    test "scalar string result passes through Jido.Exec validation" do
+      action_module = ScalarRawResource.Jido.Greet
+
+      result =
+        Jido.Exec.run(action_module, %{name: "World"}, %{domain: ExecTestDomain})
+
+      assert {:ok, %{result: "Hello, World!"}} = result
+    end
+
+    test "list result passes through Jido.Exec validation" do
+      action_module = ScalarRawResource.Jido.GetTags
+
+      result = Jido.Exec.run(action_module, %{}, %{domain: ExecTestDomain})
+
+      assert {:ok, %{result: ["alpha", "beta", "gamma"]}} = result
+    end
+  end
+end

--- a/test/ash_jido/mapper_test.exs
+++ b/test/ash_jido/mapper_test.exs
@@ -111,10 +111,52 @@ defmodule AshJido.MapperTest do
       assert {:ok, []} = result
     end
 
-    test "handles nil data" do
+    test "wraps nil data in result map" do
       result = Mapper.wrap_result({:ok, nil}, %{output_map?: true})
 
-      assert {:ok, nil} = result
+      assert {:ok, %{result: nil}} = result
+    end
+
+    test "wraps string result in map" do
+      result = Mapper.wrap_result({:ok, "hello"}, %{output_map?: true})
+
+      assert {:ok, %{result: "hello"}} = result
+    end
+
+    test "wraps integer result in map" do
+      result = Mapper.wrap_result({:ok, 42}, %{output_map?: true})
+
+      assert {:ok, %{result: 42}} = result
+    end
+
+    test "wraps boolean result in map" do
+      result = Mapper.wrap_result({:ok, true}, %{output_map?: true})
+
+      assert {:ok, %{result: true}} = result
+    end
+
+    test "wraps atom result in map" do
+      result = Mapper.wrap_result({:ok, :custom_atom}, %{output_map?: true})
+
+      assert {:ok, %{result: :custom_atom}} = result
+    end
+
+    test "wraps raw string (from Ash generic action) in map" do
+      result = Mapper.wrap_result("raw string", %{output_map?: true})
+
+      assert {:ok, %{result: "raw string"}} = result
+    end
+
+    test "wraps raw integer in map" do
+      result = Mapper.wrap_result(123, %{output_map?: true})
+
+      assert {:ok, %{result: 123}} = result
+    end
+
+    test "passes map results through unchanged" do
+      result = Mapper.wrap_result({:ok, %{key: "value"}}, %{output_map?: true})
+
+      assert {:ok, %{key: "value"}} = result
     end
 
     test "converts exception with fallback when Jido.Error not available" do

--- a/test/ash_jido/mapper_test.exs
+++ b/test/ash_jido/mapper_test.exs
@@ -17,7 +17,7 @@ defmodule AshJido.MapperTest do
       assert {:ok, %{id: "123", name: "John", email: "john@example.com", age: 30}} = result
     end
 
-    test "converts list of resources to list of maps" do
+    test "wraps list of resources in result map" do
       users = [
         %User{id: "1", name: "Alice", email: "alice@example.com", age: 25},
         %User{id: "2", name: "Bob", email: "bob@example.com", age: 35}
@@ -25,11 +25,8 @@ defmodule AshJido.MapperTest do
 
       result = Mapper.wrap_result({:ok, users}, %{output_map?: true})
 
-      assert {:ok,
-              [
-                %{id: "1", name: "Alice", email: "alice@example.com", age: 25},
-                %{id: "2", name: "Bob", email: "bob@example.com", age: 35}
-              ]} = result
+      assert {:ok, %{result: converted_users}} = result
+      assert [%{id: "1", name: "Alice"}, %{id: "2", name: "Bob"}] = converted_users
     end
 
     test "skips conversion when output_map? false" do
@@ -48,14 +45,14 @@ defmodule AshJido.MapperTest do
       assert {:ok, %{id: "456", name: "Jane", email: "jane@example.com", age: 28}} = result
     end
 
-    test "handles raw list without tuple wrapper" do
+    test "wraps raw list in result map" do
       users = [
         %User{id: "1", name: "Alice", email: "alice@example.com", age: 25}
       ]
 
       result = Mapper.wrap_result(users, %{output_map?: true})
 
-      assert {:ok, [%{id: "1", name: "Alice", email: "alice@example.com", age: 25}]} = result
+      assert {:ok, %{result: [%{id: "1", name: "Alice"}]}} = result
     end
 
     test "propagates non-exception errors unchanged" do
@@ -105,10 +102,10 @@ defmodule AshJido.MapperTest do
       assert {:ok, %{id: "123", name: "John", email: "john@example.com", age: 30}} = result
     end
 
-    test "handles empty list" do
+    test "wraps empty list in result map" do
       result = Mapper.wrap_result({:ok, []}, %{output_map?: true})
 
-      assert {:ok, []} = result
+      assert {:ok, %{result: []}} = result
     end
 
     test "wraps nil data in result map" do

--- a/test/ash_jido/module_name_override_test.exs
+++ b/test/ash_jido/module_name_override_test.exs
@@ -158,7 +158,7 @@ defmodule AshJido.ModuleNameOverrideTest do
       read_result = AshJido.Test.Readers.AllItemsReader.run(%{}, context)
 
       case read_result do
-        {:ok, items} when is_list(items) ->
+        {:ok, %{result: items}} when is_list(items) ->
           assert length(items) >= 2
           titles = Enum.map(items, & &1[:title])
           assert "Item 1" in titles

--- a/test/ash_jido/query_params_test.exs
+++ b/test/ash_jido/query_params_test.exs
@@ -120,7 +120,7 @@ defmodule AshJido.QueryParamsTest do
     setup :create_test_users
 
     test "filters by exact equality", %{users: _users} do
-      {:ok, result} =
+      {:ok, %{result: result}} =
         AshJido.Test.User.Jido.Read.run(
           %{filter: %{name: "Alice"}},
           %{domain: AshJido.Test.Domain}
@@ -131,7 +131,7 @@ defmodule AshJido.QueryParamsTest do
     end
 
     test "filters with greater_than operator", %{users: _users} do
-      {:ok, result} =
+      {:ok, %{result: result}} =
         AshJido.Test.User.Jido.Read.run(
           %{filter: %{age: %{greater_than: 28}}},
           %{domain: AshJido.Test.Domain}
@@ -144,7 +144,7 @@ defmodule AshJido.QueryParamsTest do
     end
 
     test "filters with in operator", %{users: _users} do
-      {:ok, result} =
+      {:ok, %{result: result}} =
         AshJido.Test.User.Jido.Read.run(
           %{filter: %{name: %{in: ["Alice", "Bob"]}}},
           %{domain: AshJido.Test.Domain}
@@ -154,7 +154,7 @@ defmodule AshJido.QueryParamsTest do
     end
 
     test "filters with multiple conditions (AND)", %{users: _users} do
-      {:ok, result} =
+      {:ok, %{result: result}} =
         AshJido.Test.User.Jido.Read.run(
           %{filter: %{active: true, age: %{greater_than: 28}}},
           %{domain: AshJido.Test.Domain}
@@ -169,7 +169,7 @@ defmodule AshJido.QueryParamsTest do
     setup :create_test_users
 
     test "sorts ascending", %{users: _users} do
-      {:ok, result} =
+      {:ok, %{result: result}} =
         AshJido.Test.User.Jido.Read.run(
           %{sort: [age: :asc]},
           %{domain: AshJido.Test.Domain}
@@ -180,7 +180,7 @@ defmodule AshJido.QueryParamsTest do
     end
 
     test "sorts descending", %{users: _users} do
-      {:ok, result} =
+      {:ok, %{result: result}} =
         AshJido.Test.User.Jido.Read.run(
           %{sort: [age: :desc]},
           %{domain: AshJido.Test.Domain}
@@ -191,7 +191,7 @@ defmodule AshJido.QueryParamsTest do
     end
 
     test "sorts using JSON-style sort entries", %{users: _users} do
-      {:ok, result} =
+      {:ok, %{result: result}} =
         AshJido.Test.User.Jido.Read.run(
           %{sort: [%{"field" => "age", "direction" => "desc"}]},
           %{domain: AshJido.Test.Domain}
@@ -206,7 +206,7 @@ defmodule AshJido.QueryParamsTest do
     setup :create_test_users
 
     test "limits results", %{users: _users} do
-      {:ok, result} =
+      {:ok, %{result: result}} =
         AshJido.Test.User.Jido.Read.run(
           %{sort: [age: :asc], limit: 2},
           %{domain: AshJido.Test.Domain}
@@ -216,7 +216,7 @@ defmodule AshJido.QueryParamsTest do
     end
 
     test "offsets results", %{users: _users} do
-      {:ok, result} =
+      {:ok, %{result: result}} =
         AshJido.Test.User.Jido.Read.run(
           %{sort: [age: :asc], offset: 1},
           %{domain: AshJido.Test.Domain}
@@ -227,7 +227,7 @@ defmodule AshJido.QueryParamsTest do
     end
 
     test "combines limit and offset", %{users: _users} do
-      {:ok, result} =
+      {:ok, %{result: result}} =
         AshJido.Test.User.Jido.Read.run(
           %{sort: [age: :asc], limit: 1, offset: 1},
           %{domain: AshJido.Test.Domain}
@@ -242,7 +242,7 @@ defmodule AshJido.QueryParamsTest do
     setup :create_test_users
 
     test "filter + sort + limit", %{users: _users} do
-      {:ok, result} =
+      {:ok, %{result: result}} =
         AshJido.Test.User.Jido.Read.run(
           %{filter: %{active: true}, sort: [age: :desc], limit: 2},
           %{domain: AshJido.Test.Domain}
@@ -258,7 +258,7 @@ defmodule AshJido.QueryParamsTest do
     setup :create_test_users
 
     test "works normally without query params", %{users: _users} do
-      {:ok, result} =
+      {:ok, %{result: result}} =
         AshJido.Test.User.Jido.Read.run(
           %{},
           %{domain: AshJido.Test.Domain}
@@ -273,7 +273,7 @@ defmodule AshJido.QueryParamsTest do
     setup :create_test_users
 
     test "extracts string-keyed filter and limit params", %{users: _users} do
-      {:ok, result} =
+      {:ok, %{result: result}} =
         AshJido.Test.User.Jido.Read.run(
           %{"filter" => %{"name" => "Alice"}, "limit" => 1},
           %{domain: AshJido.Test.Domain}
@@ -284,7 +284,7 @@ defmodule AshJido.QueryParamsTest do
     end
 
     test "extracts string-keyed sort params", %{users: _users} do
-      {:ok, result} =
+      {:ok, %{result: result}} =
         AshJido.Test.User.Jido.Read.run(
           %{"sort" => [%{"field" => "age", "direction" => "desc"}]},
           %{domain: AshJido.Test.Domain}
@@ -319,7 +319,7 @@ defmodule AshJido.QueryParamsTest do
         )
 
       # Request limit: 100, but max_page_size is 2
-      {:ok, result} =
+      {:ok, %{result: result}} =
         module_name.run(
           %{sort: [age: :asc], limit: 100},
           %{domain: AshJido.Test.Domain}
@@ -349,7 +349,7 @@ defmodule AshJido.QueryParamsTest do
         )
 
       # Request limit: 2, which is within max_page_size 10
-      {:ok, result} =
+      {:ok, %{result: result}} =
         module_name.run(
           %{sort: [age: :asc], limit: 2},
           %{domain: AshJido.Test.Domain}

--- a/test/integration/ash_jido_integration_test.exs
+++ b/test/integration/ash_jido_integration_test.exs
@@ -171,7 +171,7 @@ defmodule AshJido.IntegrationTest do
       read_result = User.Jido.Read.run(%{}, context)
 
       case read_result do
-        {:ok, users} when is_list(users) ->
+        {:ok, %{result: users}} when is_list(users) ->
           assert length(users) >= 1
           found_user = Enum.find(users, &(&1[:email] == "jane@example.com"))
           assert found_user != nil

--- a/test/integration/guide_examples_test.exs
+++ b/test/integration/guide_examples_test.exs
@@ -200,7 +200,7 @@ defmodule AshJido.GuideExamplesTest do
           %{domain: Domain}
         )
 
-      {:ok, posts} = Post.Jido.Read.run(%{}, %{domain: Domain})
+      {:ok, %{result: posts}} = Post.Jido.Read.run(%{}, %{domain: Domain})
       loaded_post = Enum.find(posts, &(&1[:id] == post[:id]))
 
       assert loaded_post[:author][:id] == author.id

--- a/test/integration/relationship_load_test.exs
+++ b/test/integration/relationship_load_test.exs
@@ -112,7 +112,7 @@ defmodule AshJido.RelationshipLoadTest do
           %{domain: Domain}
         )
 
-      {:ok, articles} = ArticleWithActionLoad.Jido.Read.run(%{}, %{domain: Domain})
+      {:ok, %{result: articles}} = ArticleWithActionLoad.Jido.Read.run(%{}, %{domain: Domain})
       article = Enum.find(articles, &(&1[:title] == "Action Load"))
 
       assert is_map(article)
@@ -132,7 +132,9 @@ defmodule AshJido.RelationshipLoadTest do
           %{domain: Domain}
         )
 
-      {:ok, articles} = ArticleWithAllActionsReadLoad.Jido.Read.run(%{}, %{domain: Domain})
+      {:ok, %{result: articles}} =
+        ArticleWithAllActionsReadLoad.Jido.Read.run(%{}, %{domain: Domain})
+
       article = Enum.find(articles, &(&1[:title] == "All Actions Load"))
 
       assert is_map(article)

--- a/test/integration/telemetry_test.exs
+++ b/test/integration/telemetry_test.exs
@@ -61,7 +61,9 @@ defmodule AshJido.TelemetryTest do
       |> Ash.Changeset.for_create(:create, %{title: "hello"}, domain: Domain)
       |> Ash.create!(domain: Domain)
 
-      assert {:ok, results} = ResourceWithTelemetry.Jido.Read.run(%{}, %{domain: Domain})
+      assert {:ok, %{result: results}} =
+               ResourceWithTelemetry.Jido.Read.run(%{}, %{domain: Domain})
+
       assert is_list(results)
 
       assert_receive {:telemetry_event, [:jido, :action, :ash_jido, :start], start, start_meta}


### PR DESCRIPTION
Ash generic actions (type :action) can return non-map types like strings
or integers. Jido.Exec's output validation pipeline calls Map.split/2
on the result, which raises BadMapError for non-map values.

Fix by adding ensure_map_output/1 function that wraps non-map, non-list
primitives in %{result: value} after convert_to_maps/1 completes. This
ensures generated Jido Actions always return {:ok, map()} as required
by the Jido.Action contract, while preserving correct behavior for
nested resource conversions.

Changes:
- Add ensure_map_output/1 to wrap primitives at top level only
- Preserve existing behavior for Ash resources, lists, and structs
- Add comprehensive tests for string, integer, boolean, atom, and nil results
