### PR TITLE
Add coverage for Error, SignalEmitter, and SensorDispatchBridge

### DIFF
--- a/lib/ash_jido/error.ex
+++ b/lib/ash_jido/error.ex
@@ -66,7 +66,7 @@ defmodule AshJido.Error do
   @spec extract_underlying_errors(Exception.t()) :: [Exception.t()]
   def extract_underlying_errors(ash_error) do
     cond do
-      Map.has_key?(ash_error, :errors) and is_list(ash_error.errors) ->
+      Map.has_key?(ash_error, :errors) and is_list(ash_error.errors) and ash_error.errors != [] ->
         ash_error.errors
 
       Map.has_key?(ash_error, :error) ->

--- a/lib/ash_jido/error.ex
+++ b/lib/ash_jido/error.ex
@@ -89,12 +89,12 @@ defmodule AshJido.Error do
     |> extract_underlying_errors()
     |> Enum.flat_map(fn error ->
       case error do
-        %{field: field, message: message} when not is_nil(field) ->
-          [{field, message}]
+        %{field: field} when not is_nil(field) ->
+          [{field, error_message(error)}]
 
-        %{path: path, message: message} when is_list(path) and length(path) > 0 ->
+        %{path: path} when is_list(path) and length(path) > 0 ->
           field = List.last(path)
-          [{field, message}]
+          [{field, error_message(error)}]
 
         _ ->
           []
@@ -116,10 +116,7 @@ defmodule AshJido.Error do
     |> Enum.filter(fn error ->
       case error do
         %{__struct__: module} ->
-          module_name = module |> Module.split() |> Enum.join(".")
-
-          String.contains?(module_name, "Changeset") or
-            String.contains?(module_name, "Validation")
+          change_or_validation_error_module?(module)
 
         _ ->
           false
@@ -143,5 +140,20 @@ defmodule AshJido.Error do
       fields: extract_field_errors(ash_error),
       changeset_errors: extract_changeset_errors(ash_error)
     }
+  end
+
+  defp error_message(%{message: message}) when is_binary(message) and message != "", do: message
+  defp error_message(error) when is_exception(error), do: Exception.message(error)
+  defp error_message(error), do: inspect(error)
+
+  defp change_or_validation_error_module?(module) when is_atom(module) do
+    case Module.split(module) do
+      ["Ash", "Error", namespace | _]
+      when namespace in ["Changes", "Changeset", "Validation"] ->
+        true
+
+      _ ->
+        false
+    end
   end
 end

--- a/test/ash_jido/error_test.exs
+++ b/test/ash_jido/error_test.exs
@@ -1,0 +1,254 @@
+defmodule AshJido.ErrorTest do
+  use ExUnit.Case, async: true
+
+  alias AshJido.Error
+
+  describe "from_ash/1" do
+    test "converts Ash.Error.Invalid to validation_error" do
+      ash_error = %Ash.Error.Invalid{
+        errors: [
+          %Ash.Error.Changeset.Required{field: :name, message: "is required"}
+        ]
+      }
+
+      result = Error.from_ash(ash_error)
+
+      assert %Jido.Action.Error.InvalidInputError{} = result
+      assert result.message =~ "is required"
+      assert result.details.ash_error == ash_error
+      assert result.details.fields == %{name: ["is required"]}
+    end
+
+    test "converts Ash.Error.Forbidden to execution_error with forbidden reason" do
+      ash_error = %Ash.Error.Forbidden{
+        errors: [
+          %Ash.Error.Forbidden.Policy{message: "not authorized"}
+        ]
+      }
+
+      result = Error.from_ash(ash_error)
+
+      assert %Jido.Action.Error.ExecutionFailureError{} = result
+      assert result.details.reason == :forbidden
+      assert result.details.ash_error == ash_error
+    end
+
+    test "converts Ash.Error.Framework to internal_error" do
+      ash_error = %Ash.Error.Framework{
+        errors: [
+          %Ash.Error.Framework.InvalidReturn{message: "invalid return"}
+        ]
+      }
+
+      result = Error.from_ash(ash_error)
+
+      assert %Jido.Action.Error.InternalError{} = result
+      assert result.details.ash_error == ash_error
+    end
+
+    test "converts Ash.Error.Unknown to internal_error" do
+      ash_error = %Ash.Error.Unknown{
+        errors: [
+          %Ash.Error.Unknown.UnknownError{error: "something went wrong"}
+        ]
+      }
+
+      result = Error.from_ash(ash_error)
+
+      assert %Jido.Action.Error.InternalError{} = result
+      assert result.details.ash_error == ash_error
+    end
+
+    test "converts generic exception to execution_error" do
+      ash_error = %RuntimeError{message: "runtime error"}
+
+      result = Error.from_ash(ash_error)
+
+      assert %Jido.Action.Error.ExecutionFailureError{} = result
+      assert result.details.ash_error == ash_error
+    end
+
+    test "preserves underlying errors in details" do
+      underlying = [%Ash.Error.Changeset.Required{field: :email, message: "is required"}]
+      ash_error = %Ash.Error.Invalid{errors: underlying}
+
+      result = Error.from_ash(ash_error)
+
+      assert length(result.details.underlying_errors) == 1
+      assert hd(result.details.underlying_errors).__struct__ == Ash.Error.Changeset.Required
+    end
+  end
+
+  describe "extract_underlying_errors/1" do
+    test "extracts errors list from Ash error" do
+      errors = [
+        %Ash.Error.Changeset.Required{field: :name, message: "is required"},
+        %Ash.Error.Changeset.Required{field: :email, message: "is required"}
+      ]
+
+      ash_error = %Ash.Error.Invalid{errors: errors}
+
+      result = Error.extract_underlying_errors(ash_error)
+
+      assert length(result) == 2
+    end
+
+    test "extracts single error from error field" do
+      inner_error = %Ash.Error.Changeset.Required{field: :name, message: "is required"}
+      ash_error = %Ash.Error.Unknown{error: inner_error, errors: []}
+
+      result = Error.extract_underlying_errors(ash_error)
+
+      assert length(result) == 1
+      assert hd(result) == inner_error
+    end
+
+    test "returns empty list when no errors present" do
+      ash_error = %Ash.Error.Invalid{errors: []}
+
+      result = Error.extract_underlying_errors(ash_error)
+
+      assert result == []
+    end
+
+    test "returns empty list for exception without errors field" do
+      exception = %RuntimeError{message: "test"}
+
+      result = Error.extract_underlying_errors(exception)
+
+      assert result == []
+    end
+  end
+
+  describe "extract_field_errors/1" do
+    test "extracts field errors from changeset errors" do
+      ash_error = %Ash.Error.Invalid{
+        errors: [
+          %Ash.Error.Changeset.Required{field: :name, message: "is required"},
+          %Ash.Error.Changeset.InvalidAttribute{field: :email, message: "is invalid"}
+        ]
+      }
+
+      result = Error.extract_field_errors(ash_error)
+
+      assert result.name == ["is required"]
+      assert result.email == ["is invalid"]
+    end
+
+    test "extracts field errors from path-based errors" do
+      ash_error = %Ash.Error.Invalid{
+        errors: [
+          %Ash.Error.Changeset.InvalidAttribute{
+            path: [:user, :profile, :name],
+            message: "is too short"
+          }
+        ]
+      }
+
+      result = Error.extract_field_errors(ash_error)
+
+      assert result.name == ["is too short"]
+    end
+
+    test "groups multiple errors per field" do
+      ash_error = %Ash.Error.Invalid{
+        errors: [
+          %Ash.Error.Changeset.Required{field: :name, message: "is required"},
+          %Ash.Error.Changeset.InvalidAttribute{field: :name, message: "is too short"}
+        ]
+      }
+
+      result = Error.extract_field_errors(ash_error)
+
+      assert result.name == ["is too short", "is required"]
+    end
+
+    test "returns empty map for errors without field information" do
+      ash_error = %Ash.Error.Invalid{
+        errors: [
+          %Ash.Error.Framework.InvalidReturn{message: "invalid"}
+        ]
+      }
+
+      result = Error.extract_field_errors(ash_error)
+
+      assert result == %{}
+    end
+  end
+
+  describe "extract_changeset_errors/1" do
+    test "extracts changeset-related errors" do
+      ash_error = %Ash.Error.Invalid{
+        errors: [
+          %Ash.Error.Changeset.Required{field: :name, message: "is required"},
+          %Ash.Error.Changeset.InvalidAttribute{field: :email, message: "is invalid"},
+          %Ash.Error.Framework.InvalidReturn{message: "framework error"}
+        ]
+      }
+
+      result = Error.extract_changeset_errors(ash_error)
+
+      assert length(result) == 2
+
+      changeset_modules = Enum.map(result, & &1.type)
+      assert Ash.Error.Changeset.Required in changeset_modules
+      assert Ash.Error.Changeset.InvalidAttribute in changeset_modules
+    end
+
+    test "extracts validation-related errors" do
+      ash_error = %Ash.Error.Invalid{
+        errors: [
+          %Ash.Error.Validation.InvalidAttribute{field: :age, message: "must be positive"}
+        ]
+      }
+
+      result = Error.extract_changeset_errors(ash_error)
+
+      assert length(result) == 1
+      assert hd(result).type == Ash.Error.Validation.InvalidAttribute
+    end
+
+    test "includes error details in result" do
+      ash_error = %Ash.Error.Invalid{
+        errors: [
+          %Ash.Error.Changeset.Required{field: :name, message: "is required"}
+        ]
+      }
+
+      result = Error.extract_changeset_errors(ash_error)
+
+      assert hd(result).message =~ "is required"
+      assert is_map(hd(result).details)
+    end
+
+    test "returns empty list when no changeset errors" do
+      ash_error = %Ash.Error.Invalid{
+        errors: [
+          %Ash.Error.Framework.InvalidReturn{message: "framework error"}
+        ]
+      }
+
+      result = Error.extract_changeset_errors(ash_error)
+
+      assert result == []
+    end
+  end
+
+  describe "build_details/1" do
+    test "builds complete details map with all error information" do
+      ash_error = %Ash.Error.Invalid{
+        errors: [
+          %Ash.Error.Changeset.Required{field: :name, message: "is required"},
+          %Ash.Error.Changeset.InvalidAttribute{field: :email, message: "is invalid"}
+        ]
+      }
+
+      result = Error.from_ash(ash_error)
+
+      assert result.details.ash_error == ash_error
+      assert length(result.details.underlying_errors) == 2
+      assert map_size(result.details.fields) == 2
+      assert length(result.details.changeset_errors) == 2
+    end
+  end
+end

--- a/test/ash_jido/error_test.exs
+++ b/test/ash_jido/error_test.exs
@@ -3,11 +3,15 @@ defmodule AshJido.ErrorTest do
 
   alias AshJido.Error
 
+  defmodule WrappedError do
+    defexception [:error, message: "wrapped"]
+  end
+
   describe "from_ash/1" do
     test "converts Ash.Error.Invalid to validation_error" do
       ash_error = %Ash.Error.Invalid{
         errors: [
-          %Ash.Error.Changeset.Required{field: :name, message: "is required"}
+          %Ash.Error.Changes.Required{field: :name, type: :attribute}
         ]
       }
 
@@ -16,13 +20,13 @@ defmodule AshJido.ErrorTest do
       assert %Jido.Action.Error.InvalidInputError{} = result
       assert result.message =~ "is required"
       assert result.details.ash_error == ash_error
-      assert result.details.fields == %{name: ["is required"]}
+      assert result.details.fields == %{name: ["attribute name is required"]}
     end
 
     test "converts Ash.Error.Forbidden to execution_error with forbidden reason" do
       ash_error = %Ash.Error.Forbidden{
         errors: [
-          %Ash.Error.Forbidden.Policy{message: "not authorized"}
+          %Ash.Error.Forbidden.Policy{}
         ]
       }
 
@@ -36,7 +40,7 @@ defmodule AshJido.ErrorTest do
     test "converts Ash.Error.Framework to internal_error" do
       ash_error = %Ash.Error.Framework{
         errors: [
-          %Ash.Error.Framework.InvalidReturn{message: "invalid return"}
+          %Ash.Error.Framework.InvalidReturnType{message: "invalid return"}
         ]
       }
 
@@ -69,21 +73,21 @@ defmodule AshJido.ErrorTest do
     end
 
     test "preserves underlying errors in details" do
-      underlying = [%Ash.Error.Changeset.Required{field: :email, message: "is required"}]
+      underlying = [%Ash.Error.Changes.Required{field: :email, type: :attribute}]
       ash_error = %Ash.Error.Invalid{errors: underlying}
 
       result = Error.from_ash(ash_error)
 
       assert length(result.details.underlying_errors) == 1
-      assert hd(result.details.underlying_errors).__struct__ == Ash.Error.Changeset.Required
+      assert hd(result.details.underlying_errors).__struct__ == Ash.Error.Changes.Required
     end
   end
 
   describe "extract_underlying_errors/1" do
     test "extracts errors list from Ash error" do
       errors = [
-        %Ash.Error.Changeset.Required{field: :name, message: "is required"},
-        %Ash.Error.Changeset.Required{field: :email, message: "is required"}
+        %Ash.Error.Changes.Required{field: :name, type: :attribute},
+        %Ash.Error.Changes.Required{field: :email, type: :attribute}
       ]
 
       ash_error = %Ash.Error.Invalid{errors: errors}
@@ -94,8 +98,8 @@ defmodule AshJido.ErrorTest do
     end
 
     test "extracts single error from error field" do
-      inner_error = %Ash.Error.Changeset.Required{field: :name, message: "is required"}
-      ash_error = %Ash.Error.Unknown{error: inner_error, errors: []}
+      inner_error = %Ash.Error.Changes.Required{field: :name, type: :attribute}
+      ash_error = %WrappedError{error: inner_error}
 
       result = Error.extract_underlying_errors(ash_error)
 
@@ -124,24 +128,21 @@ defmodule AshJido.ErrorTest do
     test "extracts field errors from changeset errors" do
       ash_error = %Ash.Error.Invalid{
         errors: [
-          %Ash.Error.Changeset.Required{field: :name, message: "is required"},
-          %Ash.Error.Changeset.InvalidAttribute{field: :email, message: "is invalid"}
+          %Ash.Error.Changes.Required{field: :name, type: :attribute},
+          %Ash.Error.Changes.InvalidAttribute{field: :email, message: "is invalid"}
         ]
       }
 
       result = Error.extract_field_errors(ash_error)
 
-      assert result.name == ["is required"]
+      assert result.name == ["attribute name is required"]
       assert result.email == ["is invalid"]
     end
 
     test "extracts field errors from path-based errors" do
       ash_error = %Ash.Error.Invalid{
         errors: [
-          %Ash.Error.Changeset.InvalidAttribute{
-            path: [:user, :profile, :name],
-            message: "is too short"
-          }
+          %{path: [:user, :profile, :name], message: "is too short"}
         ]
       }
 
@@ -153,20 +154,20 @@ defmodule AshJido.ErrorTest do
     test "groups multiple errors per field" do
       ash_error = %Ash.Error.Invalid{
         errors: [
-          %Ash.Error.Changeset.Required{field: :name, message: "is required"},
-          %Ash.Error.Changeset.InvalidAttribute{field: :name, message: "is too short"}
+          %Ash.Error.Changes.Required{field: :name, type: :attribute},
+          %Ash.Error.Changes.InvalidAttribute{field: :name, message: "is too short"}
         ]
       }
 
       result = Error.extract_field_errors(ash_error)
 
-      assert result.name == ["is required", "is too short"]
+      assert result.name == ["attribute name is required", "is too short"]
     end
 
     test "returns empty map for errors without field information" do
       ash_error = %Ash.Error.Invalid{
         errors: [
-          %Ash.Error.Framework.InvalidReturn{message: "invalid"}
+          %Ash.Error.Framework.InvalidReturnType{message: "invalid"}
         ]
       }
 
@@ -180,9 +181,9 @@ defmodule AshJido.ErrorTest do
     test "extracts changeset-related errors" do
       ash_error = %Ash.Error.Invalid{
         errors: [
-          %Ash.Error.Changeset.Required{field: :name, message: "is required"},
-          %Ash.Error.Changeset.InvalidAttribute{field: :email, message: "is invalid"},
-          %Ash.Error.Framework.InvalidReturn{message: "framework error"}
+          %Ash.Error.Changes.Required{field: :name, type: :attribute},
+          %Ash.Error.Changes.InvalidAttribute{field: :email, message: "is invalid"},
+          %Ash.Error.Framework.InvalidReturnType{message: "framework error"}
         ]
       }
 
@@ -191,27 +192,27 @@ defmodule AshJido.ErrorTest do
       assert length(result) == 2
 
       changeset_modules = Enum.map(result, & &1.type)
-      assert Ash.Error.Changeset.Required in changeset_modules
-      assert Ash.Error.Changeset.InvalidAttribute in changeset_modules
+      assert Ash.Error.Changes.Required in changeset_modules
+      assert Ash.Error.Changes.InvalidAttribute in changeset_modules
     end
 
-    test "extracts validation-related errors" do
+    test "extracts change-related invalid attribute errors" do
       ash_error = %Ash.Error.Invalid{
         errors: [
-          %Ash.Error.Validation.InvalidAttribute{field: :age, message: "must be positive"}
+          %Ash.Error.Changes.InvalidAttribute{field: :age, message: "must be positive"}
         ]
       }
 
       result = Error.extract_changeset_errors(ash_error)
 
       assert length(result) == 1
-      assert hd(result).type == Ash.Error.Validation.InvalidAttribute
+      assert hd(result).type == Ash.Error.Changes.InvalidAttribute
     end
 
     test "includes error details in result" do
       ash_error = %Ash.Error.Invalid{
         errors: [
-          %Ash.Error.Changeset.Required{field: :name, message: "is required"}
+          %Ash.Error.Changes.Required{field: :name, type: :attribute}
         ]
       }
 
@@ -224,7 +225,7 @@ defmodule AshJido.ErrorTest do
     test "returns empty list when no changeset errors" do
       ash_error = %Ash.Error.Invalid{
         errors: [
-          %Ash.Error.Framework.InvalidReturn{message: "framework error"}
+          %Ash.Error.Framework.InvalidReturnType{message: "framework error"}
         ]
       }
 
@@ -238,8 +239,8 @@ defmodule AshJido.ErrorTest do
     test "builds complete details map with all error information" do
       ash_error = %Ash.Error.Invalid{
         errors: [
-          %Ash.Error.Changeset.Required{field: :name, message: "is required"},
-          %Ash.Error.Changeset.InvalidAttribute{field: :email, message: "is invalid"}
+          %Ash.Error.Changes.Required{field: :name, type: :attribute},
+          %Ash.Error.Changes.InvalidAttribute{field: :email, message: "is invalid"}
         ]
       }
 

--- a/test/ash_jido/error_test.exs
+++ b/test/ash_jido/error_test.exs
@@ -160,7 +160,7 @@ defmodule AshJido.ErrorTest do
 
       result = Error.extract_field_errors(ash_error)
 
-      assert result.name == ["is too short", "is required"]
+      assert result.name == ["is required", "is too short"]
     end
 
     test "returns empty map for errors without field information" do

--- a/test/ash_jido/sensor_dispatch_bridge_test.exs
+++ b/test/ash_jido/sensor_dispatch_bridge_test.exs
@@ -3,6 +3,21 @@ defmodule AshJido.SensorDispatchBridgeTest do
 
   alias AshJido.SensorDispatchBridge
 
+  defmodule EchoSensor do
+    use Jido.Sensor,
+      name: "echo_sensor",
+      description: "Emits any forwarded signal back to the configured agent ref",
+      schema: Zoi.object(%{}, coerce: true)
+
+    @impl true
+    def init(_config, _context), do: {:ok, %{}}
+
+    @impl true
+    def handle_event(%Jido.Signal{} = signal, state), do: {:ok, state, [{:emit, signal}]}
+
+    def handle_event(_event, state), do: {:ok, state}
+  end
+
   describe "forward/2" do
     test "returns error when runtime is not available (dead pid)" do
       # Create a process and kill it
@@ -19,53 +34,51 @@ defmodule AshJido.SensorDispatchBridgeTest do
     end
 
     test "returns error for invalid signal message format" do
-      # Start a mock runtime
-      pid = spawn(fn -> receive_loop() end)
+      pid = start_sensor_runtime(self())
 
       assert {:error, :invalid_signal_message} =
                SensorDispatchBridge.forward({:invalid, nil}, pid)
     end
 
     test "successfully forwards signal to runtime" do
-      # Start a mock runtime that accepts signals
       parent = self()
-      pid = spawn(fn -> signal_receiver_loop(parent) end)
+      pid = start_sensor_runtime(parent)
 
-      signal = Jido.Signal.new("test.signal", %{data: "value"})
+      {:ok, signal} = Jido.Signal.new("test.signal", %{data: "value"})
 
       assert :ok = SensorDispatchBridge.forward(signal, pid)
-      assert_receive {:signal_received, ^signal}, 500
+      assert_receive {:signal, ^signal}, 500
     end
 
     test "successfully forwards signal wrapped in tuple" do
       parent = self()
-      pid = spawn(fn -> signal_receiver_loop(parent) end)
+      pid = start_sensor_runtime(parent)
 
-      signal = Jido.Signal.new("test.signal", %{data: "value"})
+      {:ok, signal} = Jido.Signal.new("test.signal", %{data: "value"})
 
       assert :ok = SensorDispatchBridge.forward({:signal, signal}, pid)
-      assert_receive {:signal_received, ^signal}, 500
+      assert_receive {:signal, ^signal}, 500
     end
 
     test "successfully forwards signal wrapped in ok tuple" do
       parent = self()
-      pid = spawn(fn -> signal_receiver_loop(parent) end)
+      pid = start_sensor_runtime(parent)
 
-      signal = Jido.Signal.new("test.signal", %{data: "value"})
+      {:ok, signal} = Jido.Signal.new("test.signal", %{data: "value"})
 
       assert :ok = SensorDispatchBridge.forward({:signal, {:ok, signal}}, pid)
-      assert_receive {:signal_received, ^signal}, 500
+      assert_receive {:signal, ^signal}, 500
     end
   end
 
   describe "forward_many/2" do
     test "forwards multiple signals and counts successes" do
       parent = self()
-      pid = spawn(fn -> signal_receiver_loop(parent) end)
+      pid = start_sensor_runtime(parent)
 
-      signal1 = Jido.Signal.new("test.signal1", %{id: 1})
-      signal2 = Jido.Signal.new("test.signal2", %{id: 2})
-      signal3 = Jido.Signal.new("test.signal3", %{id: 3})
+      {:ok, signal1} = Jido.Signal.new("test.signal1", %{id: 1})
+      {:ok, signal2} = Jido.Signal.new("test.signal2", %{id: 2})
+      {:ok, signal3} = Jido.Signal.new("test.signal3", %{id: 3})
 
       messages = [
         signal1,
@@ -78,16 +91,16 @@ defmodule AshJido.SensorDispatchBridgeTest do
       assert result.forwarded == 3
       assert result.errors == []
 
-      assert_receive {:signal_received, ^signal1}, 500
-      assert_receive {:signal_received, ^signal2}, 500
-      assert_receive {:signal_received, ^signal3}, 500
+      assert_receive {:signal, ^signal1}, 500
+      assert_receive {:signal, ^signal2}, 500
+      assert_receive {:signal, ^signal3}, 500
     end
 
     test "tracks errors for invalid signals" do
       parent = self()
-      pid = spawn(fn -> signal_receiver_loop(parent) end)
+      pid = start_sensor_runtime(parent)
 
-      signal = Jido.Signal.new("test.signal", %{})
+      {:ok, signal} = Jido.Signal.new("test.signal", %{})
       invalid_message = {:invalid, "format"}
 
       messages = [signal, invalid_message]
@@ -104,7 +117,7 @@ defmodule AshJido.SensorDispatchBridgeTest do
       dead_pid = spawn(fn -> nil end)
       Process.sleep(10)
 
-      signal = Jido.Signal.new("test.signal", %{})
+      {:ok, signal} = Jido.Signal.new("test.signal", %{})
 
       result = SensorDispatchBridge.forward_many([signal], dead_pid)
 
@@ -114,7 +127,7 @@ defmodule AshJido.SensorDispatchBridgeTest do
     end
 
     test "returns empty result for empty list" do
-      pid = spawn(fn -> receive_loop() end)
+      pid = start_sensor_runtime(self())
 
       result = SensorDispatchBridge.forward_many([], pid)
 
@@ -126,15 +139,15 @@ defmodule AshJido.SensorDispatchBridgeTest do
   describe "forward_or_ignore/2" do
     test "returns :ok on successful forward" do
       parent = self()
-      pid = spawn(fn -> signal_receiver_loop(parent) end)
+      pid = start_sensor_runtime(parent)
 
-      signal = Jido.Signal.new("test.signal", %{})
+      {:ok, signal} = Jido.Signal.new("test.signal", %{})
 
       assert :ok = SensorDispatchBridge.forward_or_ignore(signal, pid)
     end
 
     test "returns :ignored for invalid signal message" do
-      pid = spawn(fn -> receive_loop() end)
+      pid = start_sensor_runtime(self())
 
       assert :ignored = SensorDispatchBridge.forward_or_ignore({:invalid, nil}, pid)
     end
@@ -143,29 +156,16 @@ defmodule AshJido.SensorDispatchBridgeTest do
       dead_pid = spawn(fn -> nil end)
       Process.sleep(10)
 
-      signal = Jido.Signal.new("test.signal", %{})
+      {:ok, signal} = Jido.Signal.new("test.signal", %{})
 
       assert {:error, :runtime_unavailable} =
                SensorDispatchBridge.forward_or_ignore(signal, dead_pid)
     end
   end
 
-  # Helper functions for test processes
-
-  defp receive_loop do
-    receive do
-      _ -> receive_loop()
-    end
-  end
-
-  defp signal_receiver_loop(parent) do
-    receive do
-      {:signal, signal} ->
-        send(parent, {:signal_received, signal})
-        signal_receiver_loop(parent)
-
-      _ ->
-        signal_receiver_loop(parent)
-    end
+  defp start_sensor_runtime(agent_ref) do
+    start_supervised!(
+      {Jido.Sensor.Runtime, sensor: EchoSensor, config: %{}, context: %{agent_ref: agent_ref}}
+    )
   end
 end

--- a/test/ash_jido/sensor_dispatch_bridge_test.exs
+++ b/test/ash_jido/sensor_dispatch_bridge_test.exs
@@ -1,0 +1,171 @@
+defmodule AshJido.SensorDispatchBridgeTest do
+  use ExUnit.Case, async: true
+
+  alias AshJido.SensorDispatchBridge
+
+  describe "forward/2" do
+    test "returns error when runtime is not available (dead pid)" do
+      # Create a process and kill it
+      pid = spawn(fn -> nil end)
+      # Ensure process dies
+      Process.sleep(10)
+
+      assert {:error, :runtime_unavailable} = SensorDispatchBridge.forward({:signal, nil}, pid)
+    end
+
+    test "returns error when named process is not registered" do
+      assert {:error, :runtime_unavailable} =
+               SensorDispatchBridge.forward({:signal, nil}, :nonexistent_runtime)
+    end
+
+    test "returns error for invalid signal message format" do
+      # Start a mock runtime
+      pid = spawn(fn -> receive_loop() end)
+
+      assert {:error, :invalid_signal_message} =
+               SensorDispatchBridge.forward({:invalid, nil}, pid)
+    end
+
+    test "successfully forwards signal to runtime" do
+      # Start a mock runtime that accepts signals
+      parent = self()
+      pid = spawn(fn -> signal_receiver_loop(parent) end)
+
+      signal = Jido.Signal.new("test.signal", %{data: "value"})
+
+      assert :ok = SensorDispatchBridge.forward(signal, pid)
+      assert_receive {:signal_received, ^signal}, 500
+    end
+
+    test "successfully forwards signal wrapped in tuple" do
+      parent = self()
+      pid = spawn(fn -> signal_receiver_loop(parent) end)
+
+      signal = Jido.Signal.new("test.signal", %{data: "value"})
+
+      assert :ok = SensorDispatchBridge.forward({:signal, signal}, pid)
+      assert_receive {:signal_received, ^signal}, 500
+    end
+
+    test "successfully forwards signal wrapped in ok tuple" do
+      parent = self()
+      pid = spawn(fn -> signal_receiver_loop(parent) end)
+
+      signal = Jido.Signal.new("test.signal", %{data: "value"})
+
+      assert :ok = SensorDispatchBridge.forward({:signal, {:ok, signal}}, pid)
+      assert_receive {:signal_received, ^signal}, 500
+    end
+  end
+
+  describe "forward_many/2" do
+    test "forwards multiple signals and counts successes" do
+      parent = self()
+      pid = spawn(fn -> signal_receiver_loop(parent) end)
+
+      signal1 = Jido.Signal.new("test.signal1", %{id: 1})
+      signal2 = Jido.Signal.new("test.signal2", %{id: 2})
+      signal3 = Jido.Signal.new("test.signal3", %{id: 3})
+
+      messages = [
+        signal1,
+        {:signal, signal2},
+        {:signal, {:ok, signal3}}
+      ]
+
+      result = SensorDispatchBridge.forward_many(messages, pid)
+
+      assert result.forwarded == 3
+      assert result.errors == []
+
+      assert_receive {:signal_received, ^signal1}, 500
+      assert_receive {:signal_received, ^signal2}, 500
+      assert_receive {:signal_received, ^signal3}, 500
+    end
+
+    test "tracks errors for invalid signals" do
+      parent = self()
+      pid = spawn(fn -> signal_receiver_loop(parent) end)
+
+      signal = Jido.Signal.new("test.signal", %{})
+      invalid_message = {:invalid, "format"}
+
+      messages = [signal, invalid_message]
+
+      result = SensorDispatchBridge.forward_many(messages, pid)
+
+      assert result.forwarded == 1
+      assert length(result.errors) == 1
+      assert hd(result.errors).reason == :invalid_signal_message
+      assert hd(result.errors).message == invalid_message
+    end
+
+    test "tracks errors for unavailable runtime" do
+      dead_pid = spawn(fn -> nil end)
+      Process.sleep(10)
+
+      signal = Jido.Signal.new("test.signal", %{})
+
+      result = SensorDispatchBridge.forward_many([signal], dead_pid)
+
+      assert result.forwarded == 0
+      assert length(result.errors) == 1
+      assert hd(result.errors).reason == :runtime_unavailable
+    end
+
+    test "returns empty result for empty list" do
+      pid = spawn(fn -> receive_loop() end)
+
+      result = SensorDispatchBridge.forward_many([], pid)
+
+      assert result.forwarded == 0
+      assert result.errors == []
+    end
+  end
+
+  describe "forward_or_ignore/2" do
+    test "returns :ok on successful forward" do
+      parent = self()
+      pid = spawn(fn -> signal_receiver_loop(parent) end)
+
+      signal = Jido.Signal.new("test.signal", %{})
+
+      assert :ok = SensorDispatchBridge.forward_or_ignore(signal, pid)
+    end
+
+    test "returns :ignored for invalid signal message" do
+      pid = spawn(fn -> receive_loop() end)
+
+      assert :ignored = SensorDispatchBridge.forward_or_ignore({:invalid, nil}, pid)
+    end
+
+    test "returns error for unavailable runtime" do
+      dead_pid = spawn(fn -> nil end)
+      Process.sleep(10)
+
+      signal = Jido.Signal.new("test.signal", %{})
+
+      assert {:error, :runtime_unavailable} =
+               SensorDispatchBridge.forward_or_ignore(signal, dead_pid)
+    end
+  end
+
+  # Helper functions for test processes
+
+  defp receive_loop do
+    receive do
+      _ -> receive_loop()
+    end
+  end
+
+  defp signal_receiver_loop(parent) do
+    receive do
+      {:signal, signal} ->
+        send(parent, {:signal_received, signal})
+        signal_receiver_loop(parent)
+
+      _ ->
+        signal_receiver_loop(parent)
+    end
+  end
+end

--- a/test/ash_jido/signal_emitter_test.exs
+++ b/test/ash_jido/signal_emitter_test.exs
@@ -1,0 +1,469 @@
+defmodule AshJido.SignalEmitterTest do
+  use ExUnit.Case, async: true
+
+  alias AshJido.SignalEmitter
+  alias Jido.Action.Error
+
+  defmodule TestResource do
+    defstruct [:id, :name]
+  end
+
+  describe "validate_dispatch_config/5" do
+    test "returns :ok for non-mutating actions regardless of config" do
+      context = %{}
+      jido_config = %{emit_signals?: true}
+
+      assert :ok =
+               SignalEmitter.validate_dispatch_config(
+                 context,
+                 jido_config,
+                 TestResource,
+                 :read,
+                 :read
+               )
+
+      assert :ok =
+               SignalEmitter.validate_dispatch_config(
+                 context,
+                 jido_config,
+                 TestResource,
+                 :custom,
+                 :custom_action
+               )
+    end
+
+    test "returns :ok when emit_signals? is false" do
+      context = %{}
+      jido_config = %{emit_signals?: false, signal_dispatch: nil}
+
+      assert :ok =
+               SignalEmitter.validate_dispatch_config(
+                 context,
+                 jido_config,
+                 TestResource,
+                 :create,
+                 :create
+               )
+    end
+
+    test "returns error when emit_signals? is true but no dispatch configured" do
+      context = %{domain: AshJido.Test.Domain}
+      jido_config = %{emit_signals?: true, signal_dispatch: nil}
+
+      assert {:error, %Error.InvalidInputError{} = error} =
+               SignalEmitter.validate_dispatch_config(
+                 context,
+                 jido_config,
+                 TestResource,
+                 :create,
+                 :create
+               )
+
+      assert error.message =~ "signal dispatch configuration is required"
+      assert error.details.field == :signal_dispatch
+    end
+
+    test "validates dispatch configuration from jido_config" do
+      context = %{}
+
+      jido_config = %{
+        emit_signals?: true,
+        signal_dispatch: {:pid, target: self()}
+      }
+
+      assert :ok =
+               SignalEmitter.validate_dispatch_config(
+                 context,
+                 jido_config,
+                 TestResource,
+                 :create,
+                 :create
+               )
+    end
+
+    test "validates dispatch configuration from context" do
+      context = %{signal_dispatch: {:pid, target: self()}}
+      jido_config = %{emit_signals?: true, signal_dispatch: nil}
+
+      assert :ok =
+               SignalEmitter.validate_dispatch_config(
+                 context,
+                 jido_config,
+                 TestResource,
+                 :create,
+                 :create
+               )
+    end
+
+    test "returns error for invalid dispatch configuration" do
+      context = %{}
+
+      jido_config = %{
+        emit_signals?: true,
+        signal_dispatch: {:invalid, option: "value"}
+      }
+
+      assert {:error, %Error.InvalidInputError{} = error} =
+               SignalEmitter.validate_dispatch_config(
+                 context,
+                 jido_config,
+                 TestResource,
+                 :create,
+                 :create
+               )
+
+      assert error.message =~ "invalid signal dispatch configuration"
+      assert error.details.field == :signal_dispatch
+    end
+
+    test "context dispatch overrides jido_config dispatch" do
+      context = %{signal_dispatch: {:pid, target: self()}}
+
+      jido_config = %{
+        emit_signals?: true,
+        signal_dispatch: {:invalid, option: "value"}
+      }
+
+      # Context's valid dispatch should override jido_config's invalid one
+      assert :ok =
+               SignalEmitter.validate_dispatch_config(
+                 context,
+                 jido_config,
+                 TestResource,
+                 :create,
+                 :create
+               )
+    end
+  end
+
+  describe "resolve_dispatch_config/2" do
+    test "returns context dispatch when present" do
+      context = %{signal_dispatch: {:pid, target: self()}}
+      jido_config = %{signal_dispatch: {:bus, name: :test}}
+
+      assert {:pid, target: _} = SignalEmitter.resolve_dispatch_config(context, jido_config)
+    end
+
+    test "returns jido_config dispatch when context has no dispatch" do
+      context = %{}
+      jido_config = %{signal_dispatch: {:bus, name: :test}}
+
+      assert {:bus, name: :test} = SignalEmitter.resolve_dispatch_config(context, jido_config)
+    end
+
+    test "returns nil when neither has dispatch" do
+      context = %{}
+      jido_config = %{signal_dispatch: nil}
+
+      assert nil == SignalEmitter.resolve_dispatch_config(context, jido_config)
+    end
+  end
+
+  describe "emit_notifications/5" do
+    test "emits notification as signal" do
+      context = %{}
+      resource = AshJido.Test.User
+      action_name = :create
+
+      jido_config = %{
+        emit_signals?: true,
+        signal_dispatch: {:pid, target: self()},
+        signal_type: nil,
+        signal_source: nil
+      }
+
+      notification = %Ash.Notifier.Notification{
+        resource: resource,
+        action: %{type: :create},
+        data: %{id: "123", name: "Test"},
+        metadata: %{}
+      }
+
+      result =
+        SignalEmitter.emit_notifications(
+          [notification],
+          context,
+          resource,
+          action_name,
+          jido_config
+        )
+
+      assert result.sent == 1
+      assert result.failed == []
+
+      assert_receive {:signal, %Jido.Signal{}}, 500
+    end
+
+    test "tracks failed emissions" do
+      context = %{}
+      resource = AshJido.Test.User
+      action_name = :create
+
+      # Invalid dispatch that will fail
+      jido_config = %{
+        emit_signals?: true,
+        signal_dispatch: {:invalid, target: nil},
+        signal_type: nil,
+        signal_source: nil
+      }
+
+      notification = %Ash.Notifier.Notification{
+        resource: resource,
+        action: %{type: :create},
+        data: %{id: "123", name: "Test"},
+        metadata: %{}
+      }
+
+      result =
+        SignalEmitter.emit_notifications(
+          [notification],
+          context,
+          resource,
+          action_name,
+          jido_config
+        )
+
+      assert result.sent == 0
+      assert length(result.failed) == 1
+    end
+
+    test "handles empty notifications list" do
+      context = %{}
+      resource = AshJido.Test.User
+      action_name = :create
+
+      jido_config = %{
+        emit_signals?: true,
+        signal_dispatch: {:pid, target: self()},
+        signal_type: nil,
+        signal_source: nil
+      }
+
+      result = SignalEmitter.emit_notifications([], context, resource, action_name, jido_config)
+
+      assert result.sent == 0
+      assert result.failed == []
+    end
+
+    test "handles multiple notifications with mixed success/failure" do
+      context = %{}
+      resource = AshJido.Test.User
+      action_name = :create
+
+      # This will work for first notification, fail for second
+      jido_config = %{
+        emit_signals?: true,
+        signal_dispatch: {:pid, target: self()},
+        signal_type: nil,
+        signal_source: nil
+      }
+
+      notification1 = %Ash.Notifier.Notification{
+        resource: resource,
+        action: %{type: :create},
+        data: %{id: "1", name: "First"},
+        metadata: %{}
+      }
+
+      # Note: Since we're using the same valid dispatch, both should succeed
+      # To test failure, we'd need to mock or use a different dispatch
+      notifications = [notification1]
+
+      result =
+        SignalEmitter.emit_notifications(
+          notifications,
+          context,
+          resource,
+          action_name,
+          jido_config
+        )
+
+      assert result.sent == 1
+      assert result.failed == []
+    end
+
+    test "uses custom signal type when provided" do
+      context = %{}
+      resource = AshJido.Test.User
+      action_name = :create
+
+      jido_config = %{
+        emit_signals?: true,
+        signal_dispatch: {:pid, target: self()},
+        signal_type: "custom.event.type",
+        signal_source: nil
+      }
+
+      notification = %Ash.Notifier.Notification{
+        resource: resource,
+        action: %{type: :create},
+        data: %{id: "123", name: "Test"},
+        metadata: %{}
+      }
+
+      SignalEmitter.emit_notifications(
+        [notification],
+        context,
+        resource,
+        action_name,
+        jido_config
+      )
+
+      assert_receive {:signal, %Jido.Signal{type: "custom.event.type"}}, 500
+    end
+
+    test "uses custom signal source when provided" do
+      context = %{}
+      resource = AshJido.Test.User
+      action_name = :create
+
+      jido_config = %{
+        emit_signals?: true,
+        signal_dispatch: {:pid, target: self()},
+        signal_type: nil,
+        signal_source: "/custom/source/path"
+      }
+
+      notification = %Ash.Notifier.Notification{
+        resource: resource,
+        action: %{type: :create},
+        data: %{id: "123", name: "Test"},
+        metadata: %{}
+      }
+
+      SignalEmitter.emit_notifications(
+        [notification],
+        context,
+        resource,
+        action_name,
+        jido_config
+      )
+
+      assert_receive {:signal, %Jido.Signal{source: "/custom/source/path"}}, 500
+    end
+  end
+
+  describe "default signal type and source generation" do
+    test "generates correct default signal type from resource and action" do
+      context = %{}
+      resource = AshJido.Test.User
+      action_name = :create
+
+      jido_config = %{
+        emit_signals?: true,
+        signal_dispatch: {:pid, target: self()},
+        signal_type: nil,
+        signal_source: nil
+      }
+
+      notification = %Ash.Notifier.Notification{
+        resource: resource,
+        action: %{type: :create},
+        data: %{id: "123", name: "Test"},
+        metadata: %{}
+      }
+
+      SignalEmitter.emit_notifications(
+        [notification],
+        context,
+        resource,
+        action_name,
+        jido_config
+      )
+
+      # Default type should be "ash_jido.user.create"
+      assert_receive {:signal, %Jido.Signal{type: "ash_jido.user.create"}}, 500
+    end
+
+    test "generates correct default signal source from resource" do
+      context = %{}
+      resource = AshJido.Test.User
+      action_name = :create
+
+      jido_config = %{
+        emit_signals?: true,
+        signal_dispatch: {:pid, target: self()},
+        signal_type: nil,
+        signal_source: nil
+      }
+
+      notification = %Ash.Notifier.Notification{
+        resource: resource,
+        action: %{type: :create},
+        data: %{id: "123", name: "Test"},
+        metadata: %{}
+      }
+
+      SignalEmitter.emit_notifications(
+        [notification],
+        context,
+        resource,
+        action_name,
+        jido_config
+      )
+
+      # Default source should be "/ash_jido/ash_jido/test/user"
+      assert_receive {:signal, %Jido.Signal{source: "/ash_jido/ash_jido/test/user"}}, 500
+    end
+
+    test "extracts subject from data with id" do
+      context = %{}
+      resource = AshJido.Test.User
+      action_name = :create
+
+      jido_config = %{
+        emit_signals?: true,
+        signal_dispatch: {:pid, target: self()},
+        signal_type: nil,
+        signal_source: nil
+      }
+
+      notification = %Ash.Notifier.Notification{
+        resource: resource,
+        action: %{type: :create},
+        data: %{id: "user-123", name: "Test"},
+        metadata: %{}
+      }
+
+      SignalEmitter.emit_notifications(
+        [notification],
+        context,
+        resource,
+        action_name,
+        jido_config
+      )
+
+      assert_receive {:signal, %Jido.Signal{subject: "user-123"}}, 500
+    end
+
+    test "handles data without id for subject" do
+      context = %{}
+      resource = AshJido.Test.User
+      action_name = :create
+
+      jido_config = %{
+        emit_signals?: true,
+        signal_dispatch: {:pid, target: self()},
+        signal_type: nil,
+        signal_source: nil
+      }
+
+      notification = %Ash.Notifier.Notification{
+        resource: resource,
+        action: %{type: :create},
+        data: %{name: "Test"},
+        metadata: %{}
+      }
+
+      SignalEmitter.emit_notifications(
+        [notification],
+        context,
+        resource,
+        action_name,
+        jido_config
+      )
+
+      assert_receive {:signal, %Jido.Signal{subject: nil}}, 500
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- carry forward the original #10 coverage work onto current main
- align the error tests with current Ash error module names and struct shapes
- fix `AshJido.Error` helpers so modern `Ash.Error.Changes.*` errors are surfaced correctly
- update the sensor bridge tests to exercise the current Jido sensor runtime contract

## Validation
- MIX_ENV=test mix test test/ash_jido/error_test.exs test/ash_jido/sensor_dispatch_bridge_test.exs test/ash_jido/signal_emitter_test.exs
- MIX_ENV=test mix test
- mix quality

Supersedes #10.