### PR TITLE
feat: use static resource domain fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Bridge Ash Framework resources with Jido agents. Generates `Jido.Action` modules
 - Adds a `jido` DSL section to Ash resources
 - Generates `Jido.Action` modules at compile time for selected actions
 - Maps Ash argument types to NimbleOptions schemas
-- Runs actions via Ash with provided `domain`, `actor`, and `tenant`
+- Runs actions via Ash with the provided or resource-configured `domain`, `actor`, and `tenant`
 - Converts Ash errors to `Jido.Action.Error` (Splode-based) errors
 - Publishes `Jido.Signal` events from Ash action notifications
 
 ## What It Does Not Do
 
-- Auto-discover domains or resources (domain is explicit and required)
+- Auto-discover domains outside Ash resource configuration
 - Bypass Ash authorization, policies, or data layers
 
 ## Installation
@@ -104,11 +104,15 @@ end
 
 ## Context Requirements
 
-The `domain` is **required** in context. An `ArgumentError` is raised if missing.
+AshJido resolves the Ash domain in this order:
+
+1. `context[:domain]`
+2. the resource's static `domain:` configuration
+3. `ArgumentError` if neither is available
 
 ```elixir
 context = %{
-  domain: MyApp.Accounts,       # REQUIRED
+  domain: MyApp.Accounts,       # optional override when the resource has domain: MyApp.Accounts
   actor: current_user,          # optional: for authorization
   tenant: "org_123",            # optional: for multi-tenancy
   authorize?: true,             # optional: explicit authorization mode
@@ -282,7 +286,7 @@ AshJido.Tools.tools(MyApp.Accounts.User)
 ## Troubleshooting
 
 **`AshJido: :domain must be provided in context`**
-- Pass `%{domain: MyApp.Domain}` as the second argument to `run/2`
+- Pass `%{domain: MyApp.Domain}` as the second argument to `run/2`, or configure `domain: MyApp.Domain` on the Ash resource
 
 **`Update actions require an 'id' parameter`**
 - Include `id` in params for `:update` and `:destroy` actions

--- a/ash_jido_consumer/test/integration/ash_jido_real_integration_test.exs
+++ b/ash_jido_consumer/test/integration/ash_jido_real_integration_test.exs
@@ -389,10 +389,9 @@ defmodule AshJidoConsumer.RealIntegrationTest do
   end
 
   describe "failure semantics" do
-    test "missing domain raises an argument error for generated actions" do
-      assert_raise ArgumentError, ~r/AshJido: :domain must be provided in context/, fn ->
-        User.Jido.Read.run(%{}, %{})
-      end
+    test "generated actions use the resource static domain when context omits domain" do
+      assert {:ok, %{result: users}} = User.Jido.Read.run(%{}, %{})
+      assert is_list(users)
     end
 
     test "update actions require id and return deterministic errors when missing" do

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -131,7 +131,9 @@ end
 
 ## Using Generated Actions
 
-Call the generated modules using `run/2` with params and a context map. The context must include at minimum a `:domain`:
+Call the generated modules using `run/2` with params and a context map. `context[:domain]`
+overrides the Ash resource's static `domain:` configuration; if neither is available,
+AshJido raises an `ArgumentError`.
 
 ```elixir
 # Create a user

--- a/guides/walkthrough-failure-semantics.md
+++ b/guides/walkthrough-failure-semantics.md
@@ -16,7 +16,9 @@ AshJido maps Ash failures to Jido action errors.
 
 ### Missing `domain`
 
-Generated actions require `domain` in context and raise `ArgumentError` if omitted.
+Generated actions resolve the Ash domain from `context[:domain]` first, then from the
+resource's static `domain:` configuration. They raise `ArgumentError` only when both
+are missing.
 
 ```elixir
 assert_raise ArgumentError, ~r/:domain must be provided/, fn ->

--- a/guides/walkthrough-policy-scope-auth.md
+++ b/guides/walkthrough-policy-scope-auth.md
@@ -2,13 +2,14 @@
 
 This walkthrough focuses on policy-aware execution with generated AshJido actions.
 
-## 1. Context: Required vs Optional
+## 1. Context: Domain Resolution and Optional Options
 
-Generated actions always require `domain` in runtime context. All other keys are optional passthroughs.
+Generated actions use `context[:domain]` when present and otherwise fall back to
+the resource's static `domain:` configuration. All other keys are optional passthroughs.
 
 ```elixir
 context = %{
-  domain: MyApp.Accounts,      # required
+  domain: MyApp.Accounts,      # optional override when the resource has a static domain
   actor: current_user,         # optional
   tenant: "org_123",          # optional
   scope: %{actor: current_user}, # optional

--- a/guides/walkthrough-resource-to-action.md
+++ b/guides/walkthrough-resource-to-action.md
@@ -123,7 +123,9 @@ published[:status] # => :published
 
 ## 3. Pass Ash Context Through Runtime Context
 
-`domain` is required. Other Ash options are optional and passed through when present:
+`context[:domain]` is optional when the resource has a static `domain:` configuration.
+When present, it overrides the resource domain. Other Ash options are optional and
+passed through when present:
 
 ```elixir
 context = %{
@@ -188,5 +190,5 @@ end
 Important:
 
 - The agent `tools:` list should use generated module names (`MyApp.Blog.Post.Jido.*`).
-- Pass `domain` in `tool_context` so AshJido actions have required context.
+- Pass `domain` in `tool_context` when overriding the resource's static domain or when the resource has `domain: nil`.
 - Add `actor`, `tenant`, and other Ash options in `tool_context` for policy and tenancy-aware calls.

--- a/lib/ash_jido.ex
+++ b/lib/ash_jido.ex
@@ -34,10 +34,12 @@ defmodule AshJido do
 
   ## Context
 
-  The context map **requires** a `:domain` key. An `ArgumentError` is raised if missing.
+  AshJido resolves the Ash domain from `context[:domain]` first, then from the
+  resource's static `domain:` configuration. An `ArgumentError` is raised if
+  neither is available.
 
       context = %{
-        domain: MyApp.Accounts,       # REQUIRED
+        domain: MyApp.Accounts,       # optional override when the resource has a static domain
         actor: current_user,          # optional: for authorization
         tenant: "org_123",            # optional: for multi-tenancy
         authorize?: true,             # optional: explicit authorization mode

--- a/lib/ash_jido/context.ex
+++ b/lib/ash_jido/context.ex
@@ -36,8 +36,14 @@ defmodule AshJido.Context do
   defp require_domain!(context, resource, action_name) do
     case Map.get(context, :domain) do
       nil ->
-        raise ArgumentError,
-              "AshJido: :domain must be provided in context for #{inspect(resource)}.#{action_name}"
+        case Ash.Resource.Info.domain(resource) do
+          nil ->
+            raise ArgumentError,
+                  "AshJido: :domain must be provided in context for #{inspect(resource)}.#{action_name}"
+
+          domain ->
+            domain
+        end
 
       domain ->
         domain

--- a/test/ash_jido/context_test.exs
+++ b/test/ash_jido/context_test.exs
@@ -12,6 +12,28 @@ defmodule AshJido.ContextTest do
                    end
     end
 
+    test "falls back to the resource static domain when context domain is absent" do
+      opts =
+        Context.extract_ash_opts!(
+          %{},
+          AshJido.Test.ReactiveResource,
+          :read
+        )
+
+      assert opts[:domain] == AshJido.Test.ReactiveDomain
+    end
+
+    test "explicit context domain overrides the resource static domain" do
+      opts =
+        Context.extract_ash_opts!(
+          %{domain: AshJido.Test.Domain},
+          AshJido.Test.ReactiveResource,
+          :read
+        )
+
+      assert opts[:domain] == AshJido.Test.Domain
+    end
+
     test "includes existing base options and optional passthrough keys when provided" do
       tracer = [FakeTracer]
       scope = %{scope: :value}

--- a/test/integration/guide_examples_test.exs
+++ b/test/integration/guide_examples_test.exs
@@ -356,9 +356,14 @@ defmodule AshJido.GuideExamplesTest do
   end
 
   describe "failure semantics walkthrough" do
-    test "missing domain raises argument error" do
+    test "static resource domain is used when runtime context omits domain" do
+      assert {:ok, %{result: posts}} = Post.Jido.Read.run(%{}, %{})
+      assert is_list(posts)
+    end
+
+    test "resources without a static domain still raise when context omits domain" do
       assert_raise ArgumentError, ~r/AshJido: :domain must be provided in context/, fn ->
-        Post.Jido.Read.run(%{}, %{})
+        AshJido.Test.User.Jido.Read.run(%{}, %{})
       end
     end
 

--- a/test/integration/telemetry_test.exs
+++ b/test/integration/telemetry_test.exs
@@ -52,6 +52,15 @@ defmodule AshJido.TelemetryTest do
   end
 
   describe "telemetry emission" do
+    test "generated actions use the resource static domain when context omits domain" do
+      ResourceWithTelemetry
+      |> Ash.Changeset.for_create(:create, %{title: "static domain"}, domain: Domain)
+      |> Ash.create!(domain: Domain)
+
+      assert {:ok, %{result: results}} = ResourceWithTelemetry.Jido.Read.run(%{}, %{})
+      assert Enum.any?(results, &(&1[:title] == "static domain"))
+    end
+
     test "emits start and stop events for successful executions" do
       flush_telemetry_messages()
       handler_id = attach_telemetry_handler(self())

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -146,7 +146,8 @@ end
 ## Troubleshooting
 
 ### Domain Not Provided Error
-- Domain is **required** in context - provide `%{domain: MyApp.Domain}`
+- AshJido uses `context[:domain]` first, then the resource's static `domain:` configuration
+- Provide `%{domain: MyApp.Domain}` when overriding or when the resource has `domain: nil`
 - Ensure the resource is registered in the domain you're providing
 
 ### Action Not Found Error


### PR DESCRIPTION
## Summary
- Resolve Ash domains from context first, then resource static domain
- Keep the existing missing-domain error when neither source is available
- Update docs and tests for the new resolution order

## Verification
- mix test test/ash_jido/context_test.exs test/integration/telemetry_test.exs

Closes #22