### PR TITLE
fix: use resource primary keys for mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,8 +288,9 @@ AshJido.Tools.tools(MyApp.Accounts.User)
 **`AshJido: :domain must be provided in context`**
 - Pass `%{domain: MyApp.Domain}` as the second argument to `run/2`, or configure `domain: MyApp.Domain` on the Ash resource
 
-**`Update actions require an 'id' parameter`**
-- Include `id` in params for `:update` and `:destroy` actions
+**`Update actions require primary key parameter(s): ...`**
+- Include the resource's primary key field or fields in params for `:update` and `:destroy` actions
+- Resources with the default `[:id]` primary key continue to use `id`
 
 **`Action X not found in resource`**
 - Check `jido action :...` entries match defined Ash actions

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -148,13 +148,13 @@ AshJido raises an `ArgumentError`.
   %{domain: MyApp.Accounts}
 )
 
-# Update a user (requires id)
+# Update a user (requires the resource primary key; id for the default primary key)
 {:ok, updated_user} = MyApp.Accounts.User.Jido.UpdateProfile.run(
   %{id: user[:id], name: "Jane Doe"},
   %{domain: MyApp.Accounts}
 )
 
-# Delete a user (requires id)
+# Delete a user (requires the resource primary key; id for the default primary key)
 {:ok, _} = MyApp.Accounts.User.Jido.Destroy.run(
   %{id: user[:id]},
   %{domain: MyApp.Accounts}
@@ -385,8 +385,8 @@ Each Ash action type maps to corresponding behavior:
 |-----------------|----------|
 | `:create` | Creates a new record via `Ash.create!` |
 | `:read` | Queries records via `Ash.read!` |
-| `:update` | Updates a record (requires `id` param) via `Ash.update!` |
-| `:destroy` | Deletes a record (requires `id` param) via `Ash.destroy!` |
+| `:update` | Updates a record using the resource primary key fields via `Ash.update!` |
+| `:destroy` | Deletes a record using the resource primary key fields via `Ash.destroy!` |
 | `:action` | Runs custom logic via `Ash.run_action!` |
 
 ## Complete Example

--- a/guides/walkthrough-failure-semantics.md
+++ b/guides/walkthrough-failure-semantics.md
@@ -26,17 +26,20 @@ assert_raise ArgumentError, ~r/:domain must be provided/, fn ->
 end
 ```
 
-### Missing `id` for update/destroy
+### Missing primary key for update/destroy
 
 ```elixir
 assert {:error, %Jido.Action.Error.ExecutionFailureError{} = error} =
   MyApp.Content.Post.Jido.Update.run(
-    %{title: "missing id"},
+    %{title: "missing primary key"},
     %{domain: MyApp.Content}
   )
 
 error.message # => "Update actions require an 'id' parameter"
 ```
+
+Resources with a non-`id` or composite primary key report the generated primary key
+fields instead, e.g. `"Update actions require primary key parameter(s): account_id, external_id"`.
 
 ### Missing `signal_dispatch` when signaling is enabled
 

--- a/guides/walkthrough-resource-to-action.md
+++ b/guides/walkthrough-resource-to-action.md
@@ -149,7 +149,7 @@ Notes:
 
 ## 4. Rules to Remember
 
-- Update and destroy generated actions require `id` in params.
+- Update and destroy generated actions require the resource primary key field or fields in params.
 - `load` is static DSL configuration for read actions only.
 - `output_map?: true` (default) returns maps instead of Ash structs.
 

--- a/lib/ash_jido/generator.ex
+++ b/lib/ash_jido/generator.ex
@@ -73,6 +73,7 @@ defmodule AshJido.Generator do
 
     # Build input schema including accepted attributes
     schema = build_parameter_schema(resource, ash_action, jido_action, dsl_state)
+    primary_key = primary_key_fields(dsl_state)
 
     action_use_opts =
       [
@@ -98,6 +99,7 @@ defmodule AshJido.Generator do
         @ash_action unquote(ash_action.name)
         @ash_action_type unquote(ash_action.type)
         @jido_config unquote(Macro.escape(jido_action))
+        @primary_key unquote(Macro.escape(primary_key))
 
         def on_before_validate_params(params) do
           {:ok, normalize_query_param_keys(params)}
@@ -177,20 +179,13 @@ defmodule AshJido.Generator do
                 {action_result, empty_signal_meta(), false}
 
               :update ->
-                # Load the record to update using its primary key
-                record_id = Map.get(params, :id) || Map.get(params, "id")
-
-                unless record_id do
-                  raise ArgumentError, "Update actions require an 'id' parameter"
-                end
-
-                # Remove id from params to prevent it being passed to changeset
-                update_params = Map.drop(params, [:id, "id"])
+                primary_key = fetch_primary_key!(params, :update)
+                update_params = drop_primary_key_params(params)
 
                 # Load the record first
                 record =
                   @resource
-                  |> Ash.get!(record_id, ash_opts)
+                  |> Ash.get!(primary_key, ash_opts)
 
                 update_result =
                   record
@@ -213,17 +208,12 @@ defmodule AshJido.Generator do
                 {action_result, signal_emission, false}
 
               :destroy ->
-                # Load the record to destroy using its primary key
-                record_id = Map.get(params, :id) || Map.get(params, "id")
-
-                unless record_id do
-                  raise ArgumentError, "Destroy actions require an 'id' parameter"
-                end
+                primary_key = fetch_primary_key!(params, :destroy)
 
                 # Load the record first
                 record =
                   @resource
-                  |> Ash.get!(record_id, ash_opts)
+                  |> Ash.get!(primary_key, ash_opts)
 
                 destroy_result =
                   record
@@ -282,6 +272,56 @@ defmodule AshJido.Generator do
         end
 
         defp empty_signal_meta, do: %{failed: [], sent: 0}
+
+        defp fetch_primary_key!(params, action_type) do
+          values =
+            Map.new(@primary_key, fn key ->
+              {key, fetch_param(params, key)}
+            end)
+
+          missing_keys =
+            values
+            |> Enum.filter(fn {_key, value} -> is_nil(value) end)
+            |> Enum.map(fn {key, _value} -> key end)
+
+          unless Enum.empty?(missing_keys) do
+            raise ArgumentError, missing_primary_key_message(action_type, @primary_key)
+          end
+
+          case @primary_key do
+            [key] -> Map.fetch!(values, key)
+            _ -> values
+          end
+        end
+
+        defp fetch_param(params, key) do
+          case Map.fetch(params, key) do
+            {:ok, value} -> value
+            :error -> Map.get(params, to_string(key))
+          end
+        end
+
+        defp drop_primary_key_params(params) do
+          Enum.reduce(@primary_key, params, fn key, acc ->
+            Map.drop(acc, [key, to_string(key)])
+          end)
+        end
+
+        defp missing_primary_key_message(action_type, primary_key) do
+          cond do
+            action_type == :update and primary_key == [:id] ->
+              "Update actions require an 'id' parameter"
+
+            action_type == :destroy and primary_key == [:id] ->
+              "Destroy actions require an 'id' parameter"
+
+            true ->
+              action_label = action_type |> Atom.to_string() |> String.capitalize()
+              key_list = Enum.map_join(primary_key, ", ", &to_string/1)
+
+              "#{action_label} actions require primary key parameter(s): #{key_list}"
+          end
+        end
 
         defp maybe_load(query, config) do
           case config.load do
@@ -515,15 +555,15 @@ defmodule AshJido.Generator do
         accepted_attrs ++ action_args
 
       :update ->
-        # Update actions need an id field plus accepted attributes plus action arguments
-        base = [id: [type: :string, required: true, doc: "ID of record to update"]]
+        # Update actions need primary key fields plus accepted attributes plus action arguments
+        base = primary_key_to_schema(dsl_state, :update)
         accepted_attrs = accepted_attributes_to_schema(resource, ash_action, dsl_state)
         action_args = action_args_to_schema(ash_action.arguments || [])
         base ++ accepted_attrs ++ action_args
 
       :destroy ->
-        # Destroy actions just need an id
-        [id: [type: :string, required: true, doc: "ID of record to destroy"]]
+        # Destroy actions need primary key fields
+        primary_key_to_schema(dsl_state, :destroy)
 
       _ ->
         # Read and custom actions use their declared arguments
@@ -604,6 +644,40 @@ defmodule AshJido.Generator do
       end
     end)
     |> Enum.reject(&is_nil/1)
+  end
+
+  defp primary_key_fields(dsl_state) do
+    dsl_state
+    |> Transformer.get_entities([:attributes])
+    |> Enum.filter(& &1.primary_key?)
+    |> Enum.map(& &1.name)
+  end
+
+  defp primary_key_to_schema(dsl_state, action_type) do
+    primary_key = primary_key_fields(dsl_state)
+    all_attributes = Transformer.get_entities(dsl_state, [:attributes])
+
+    Enum.map(primary_key, fn attr_name ->
+      attr = Enum.find(all_attributes, &(&1.name == attr_name))
+
+      opts =
+        case attr do
+          nil -> [type: :any]
+          attr -> attribute_to_nimble_options(attr)
+        end
+
+      opts =
+        opts
+        |> Keyword.put(:required, true)
+        |> Keyword.put(:doc, primary_key_doc(attr_name, action_type))
+
+      {attr_name, opts}
+    end)
+  end
+
+  defp primary_key_doc(attr_name, action_type) do
+    action = action_type |> Atom.to_string() |> String.downcase()
+    "Primary key field #{attr_name} of record to #{action}"
   end
 
   defp attribute_to_nimble_options(attr) do

--- a/test/ash_jido/generator_test.exs
+++ b/test/ash_jido/generator_test.exs
@@ -57,6 +57,72 @@ defmodule AshJido.GeneratorTest do
     end
   end
 
+  defmodule CustomPrimaryKeyResource do
+    use Ash.Resource,
+      domain: AshJido.GeneratorTest.PrimaryKeyDomain,
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      attribute(:slug, :string, primary_key?: true, allow_nil?: false)
+      attribute(:name, :string, allow_nil?: false)
+    end
+
+    actions do
+      defaults([:read])
+
+      create :create do
+        accept([:slug, :name])
+      end
+
+      update :rename do
+        accept([:name])
+      end
+    end
+  end
+
+  defmodule CompositePrimaryKeyResource do
+    use Ash.Resource,
+      domain: AshJido.GeneratorTest.PrimaryKeyDomain,
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      attribute(:account_id, :string, primary_key?: true, allow_nil?: false)
+      attribute(:external_id, :string, primary_key?: true, allow_nil?: false)
+      attribute(:name, :string, allow_nil?: false)
+    end
+
+    actions do
+      defaults([:read])
+
+      create :create do
+        accept([:account_id, :external_id, :name])
+      end
+
+      update :rename do
+        accept([:name])
+      end
+
+      destroy(:destroy)
+    end
+  end
+
+  defmodule PrimaryKeyDomain do
+    use Ash.Domain, validate_config_inclusion?: false
+
+    resources do
+      resource(CustomPrimaryKeyResource)
+      resource(CompositePrimaryKeyResource)
+    end
+  end
+
   # Note: Most generator functions are private, so we test via the public interface
 
   describe "generate_jido_action_module/3" do
@@ -290,6 +356,158 @@ defmodule AshJido.GeneratorTest do
       schema = module_name.schema()
       assert Keyword.has_key?(schema, :id)
       assert schema[:id][:required] == true
+    end
+
+    test "update action schema uses custom primary key fields" do
+      dsl_state = CustomPrimaryKeyResource.spark_dsl_config()
+
+      jido_action = %AshJido.Resource.JidoAction{
+        action: :rename,
+        name: "rename_custom_primary_key",
+        module_name: TestCustomPrimaryKeySchemaAction,
+        description: "Rename custom primary key resource",
+        output_map?: true
+      }
+
+      module_name =
+        AshJido.Generator.generate_jido_action_module(
+          CustomPrimaryKeyResource,
+          jido_action,
+          dsl_state
+        )
+
+      schema = module_name.schema()
+
+      assert Keyword.has_key?(schema, :slug)
+      assert schema[:slug][:required] == true
+      refute Keyword.has_key?(schema, :id)
+    end
+
+    test "update action loads records by a non-id primary key" do
+      slug = "custom-#{System.unique_integer([:positive])}"
+
+      CustomPrimaryKeyResource
+      |> Ash.Changeset.for_create(:create, %{slug: slug, name: "Before"}, domain: PrimaryKeyDomain)
+      |> Ash.create!(domain: PrimaryKeyDomain)
+
+      dsl_state = CustomPrimaryKeyResource.spark_dsl_config()
+
+      jido_action = %AshJido.Resource.JidoAction{
+        action: :rename,
+        name: "rename_custom_primary_key_runtime",
+        module_name: TestCustomPrimaryKeyRuntimeAction,
+        description: "Rename custom primary key resource",
+        output_map?: true
+      }
+
+      module_name =
+        AshJido.Generator.generate_jido_action_module(
+          CustomPrimaryKeyResource,
+          jido_action,
+          dsl_state
+        )
+
+      assert {:ok, updated} =
+               module_name.run(%{"slug" => slug, name: "After"}, %{domain: PrimaryKeyDomain})
+
+      assert updated[:slug] == slug
+      assert updated[:name] == "After"
+    end
+
+    test "destroy action schema uses composite primary key fields" do
+      dsl_state = CompositePrimaryKeyResource.spark_dsl_config()
+
+      jido_action = %AshJido.Resource.JidoAction{
+        action: :destroy,
+        name: "destroy_composite_primary_key",
+        module_name: TestCompositePrimaryKeySchemaAction,
+        description: "Destroy composite primary key resource",
+        output_map?: true
+      }
+
+      module_name =
+        AshJido.Generator.generate_jido_action_module(
+          CompositePrimaryKeyResource,
+          jido_action,
+          dsl_state
+        )
+
+      schema = module_name.schema()
+
+      assert Keyword.has_key?(schema, :account_id)
+      assert Keyword.has_key?(schema, :external_id)
+      assert schema[:account_id][:required] == true
+      assert schema[:external_id][:required] == true
+      refute Keyword.has_key?(schema, :id)
+    end
+
+    test "destroy action loads records by a composite primary key" do
+      account_id = "acct-#{System.unique_integer([:positive])}"
+      external_id = "ext-#{System.unique_integer([:positive])}"
+
+      CompositePrimaryKeyResource
+      |> Ash.Changeset.for_create(
+        :create,
+        %{account_id: account_id, external_id: external_id, name: "Composite"},
+        domain: PrimaryKeyDomain
+      )
+      |> Ash.create!(domain: PrimaryKeyDomain)
+
+      dsl_state = CompositePrimaryKeyResource.spark_dsl_config()
+
+      jido_action = %AshJido.Resource.JidoAction{
+        action: :destroy,
+        name: "destroy_composite_primary_key_runtime",
+        module_name: TestCompositePrimaryKeyRuntimeAction,
+        description: "Destroy composite primary key resource",
+        output_map?: true
+      }
+
+      module_name =
+        AshJido.Generator.generate_jido_action_module(
+          CompositePrimaryKeyResource,
+          jido_action,
+          dsl_state
+        )
+
+      assert {:ok, %{deleted: true}} =
+               module_name.run(
+                 %{"account_id" => account_id, external_id: external_id},
+                 %{domain: PrimaryKeyDomain}
+               )
+
+      assert {:ok, nil} =
+               Ash.get(
+                 CompositePrimaryKeyResource,
+                 %{account_id: account_id, external_id: external_id},
+                 domain: PrimaryKeyDomain,
+                 not_found_error?: false
+               )
+    end
+
+    test "composite primary key errors list required key fields" do
+      dsl_state = CompositePrimaryKeyResource.spark_dsl_config()
+
+      jido_action = %AshJido.Resource.JidoAction{
+        action: :rename,
+        name: "rename_composite_primary_key_missing",
+        module_name: TestCompositePrimaryKeyMissingAction,
+        description: "Rename composite primary key resource",
+        output_map?: true
+      }
+
+      module_name =
+        AshJido.Generator.generate_jido_action_module(
+          CompositePrimaryKeyResource,
+          jido_action,
+          dsl_state
+        )
+
+      {:error, jido_error} =
+        module_name.run(%{account_id: "acct", name: "After"}, %{domain: PrimaryKeyDomain})
+
+      assert jido_error.message ==
+               "Update actions require primary key parameter(s): account_id, external_id"
     end
   end
 


### PR DESCRIPTION
## Summary
- Generate update/destroy schemas from each resource primary key instead of hard-coded `id`
- Load mutation records with single or composite primary keys using Ash lookup semantics
- Preserve the existing default `id` error messages while adding clear composite-key errors
- Update docs for primary-key-aware mutation params

## Verification
- mix test test/ash_jido/generator_test.exs test/ash_jido/enhanced_generator_test.exs

Closes #24