### PR TITLE
fix: pass destroy action arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ AshJido.Tools.tools(MyApp.Accounts.User)
 **`Update actions require primary key parameter(s): ...`**
 - Include the resource's primary key field or fields in params for `:update` and `:destroy` actions
 - Resources with the default `[:id]` primary key continue to use `id`
+- Destroy actions also include and pass through any declared Ash destroy action arguments
 
 **`Action X not found in resource`**
 - Check `jido action :...` entries match defined Ash actions

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -386,7 +386,7 @@ Each Ash action type maps to corresponding behavior:
 | `:create` | Creates a new record via `Ash.create!` |
 | `:read` | Queries records via `Ash.read!` |
 | `:update` | Updates a record using the resource primary key fields via `Ash.update!` |
-| `:destroy` | Deletes a record using the resource primary key fields via `Ash.destroy!` |
+| `:destroy` | Deletes a record using the resource primary key fields and declared destroy arguments via `Ash.destroy!` |
 | `:action` | Runs custom logic via `Ash.run_action!` |
 
 ## Complete Example

--- a/guides/walkthrough-failure-semantics.md
+++ b/guides/walkthrough-failure-semantics.md
@@ -41,6 +41,9 @@ error.message # => "Update actions require an 'id' parameter"
 Resources with a non-`id` or composite primary key report the generated primary key
 fields instead, e.g. `"Update actions require primary key parameter(s): account_id, external_id"`.
 
+Destroy actions also validate declared Ash destroy action arguments, so missing or
+invalid destroy arguments surface as regular Ash/Jido validation errors.
+
 ### Missing `signal_dispatch` when signaling is enabled
 
 ```elixir

--- a/guides/walkthrough-resource-to-action.md
+++ b/guides/walkthrough-resource-to-action.md
@@ -150,6 +150,7 @@ Notes:
 ## 4. Rules to Remember
 
 - Update and destroy generated actions require the resource primary key field or fields in params.
+- Destroy generated actions also accept declared Ash destroy action arguments.
 - `load` is static DSL configuration for read actions only.
 - `output_map?: true` (default) returns maps instead of Ash structs.
 

--- a/lib/ash_jido/generator.ex
+++ b/lib/ash_jido/generator.ex
@@ -209,6 +209,7 @@ defmodule AshJido.Generator do
 
               :destroy ->
                 primary_key = fetch_primary_key!(params, :destroy)
+                destroy_params = drop_primary_key_params(params)
 
                 # Load the record first
                 record =
@@ -217,7 +218,7 @@ defmodule AshJido.Generator do
 
                 destroy_result =
                   record
-                  |> Ash.Changeset.for_destroy(@ash_action, %{}, ash_opts)
+                  |> Ash.Changeset.for_destroy(@ash_action, destroy_params, ash_opts)
                   |> Ash.destroy!(maybe_add_notification_collection(ash_opts, @jido_config, :destroy))
 
                 notifications = maybe_extract_destroy_notifications(destroy_result)
@@ -562,8 +563,10 @@ defmodule AshJido.Generator do
         base ++ accepted_attrs ++ action_args
 
       :destroy ->
-        # Destroy actions need primary key fields
-        primary_key_to_schema(dsl_state, :destroy)
+        # Destroy actions need primary key fields plus action arguments
+        base = primary_key_to_schema(dsl_state, :destroy)
+        action_args = action_args_to_schema(ash_action.arguments || [])
+        base ++ action_args
 
       _ ->
         # Read and custom actions use their declared arguments

--- a/test/ash_jido/generator_test.exs
+++ b/test/ash_jido/generator_test.exs
@@ -81,6 +81,10 @@ defmodule AshJido.GeneratorTest do
       update :rename do
         accept([:name])
       end
+
+      destroy :delete_with_reason do
+        argument(:reason, :string, allow_nil?: false)
+      end
     end
   end
 
@@ -508,6 +512,72 @@ defmodule AshJido.GeneratorTest do
 
       assert jido_error.message ==
                "Update actions require primary key parameter(s): account_id, external_id"
+    end
+
+    test "destroy action schema includes declared action arguments" do
+      dsl_state = CustomPrimaryKeyResource.spark_dsl_config()
+
+      jido_action = %AshJido.Resource.JidoAction{
+        action: :delete_with_reason,
+        name: "delete_custom_primary_key_with_reason",
+        module_name: TestDestroyArgumentSchemaAction,
+        description: "Destroy custom primary key resource with reason",
+        output_map?: true
+      }
+
+      module_name =
+        AshJido.Generator.generate_jido_action_module(
+          CustomPrimaryKeyResource,
+          jido_action,
+          dsl_state
+        )
+
+      schema = module_name.schema()
+
+      assert Keyword.has_key?(schema, :slug)
+      assert Keyword.has_key?(schema, :reason)
+      assert schema[:slug][:required] == true
+      assert schema[:reason][:required] == true
+    end
+
+    test "destroy action passes declared arguments to Ash" do
+      slug = "destroy-arg-#{System.unique_integer([:positive])}"
+
+      CustomPrimaryKeyResource
+      |> Ash.Changeset.for_create(
+        :create,
+        %{slug: slug, name: "Destroy With Reason"},
+        domain: PrimaryKeyDomain
+      )
+      |> Ash.create!(domain: PrimaryKeyDomain)
+
+      dsl_state = CustomPrimaryKeyResource.spark_dsl_config()
+
+      jido_action = %AshJido.Resource.JidoAction{
+        action: :delete_with_reason,
+        name: "delete_custom_primary_key_with_reason_runtime",
+        module_name: TestDestroyArgumentRuntimeAction,
+        description: "Destroy custom primary key resource with reason",
+        output_map?: true
+      }
+
+      module_name =
+        AshJido.Generator.generate_jido_action_module(
+          CustomPrimaryKeyResource,
+          jido_action,
+          dsl_state
+        )
+
+      assert {:ok, %{deleted: true}} =
+               module_name.run(%{"slug" => slug, reason: "cleanup"}, %{domain: PrimaryKeyDomain})
+
+      assert {:ok, nil} =
+               Ash.get(
+                 CustomPrimaryKeyResource,
+                 slug,
+                 domain: PrimaryKeyDomain,
+                 not_found_error?: false
+               )
     end
   end
 


### PR DESCRIPTION
## Summary
- Include declared Ash destroy action arguments in generated Jido schemas
- Split primary-key params before destroy execution and pass the remaining params to `Ash.Changeset.for_destroy/4`
- Add runtime coverage for destroy actions that require an argument
- Document destroy argument behavior

## Verification
- mix test test/ash_jido/generator_test.exs test/ash_jido/enhanced_generator_test.exs

Replaces #39.
Closes #23