### PR TITLE
feat: default all_actions to public actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,17 @@ than once.
 
 ### Bulk Exposure
 
+`all_actions` follows Ash's public API boundary by default: it expands only actions
+marked `public?: true`. Explicit `action :name` entries remain the way to expose a
+specific private action deliberately, and `include_private?: true` is available for
+trusted/internal tool catalogs.
+
 ```elixir
 jido do
   all_actions
   all_actions except: [:destroy, :internal]
   all_actions only: [:create, :read]
+  all_actions include_private?: true
   all_actions category: "ash.resource"
   all_actions tags: ["public-api"]
   all_actions vsn: "1.0.0"
@@ -209,8 +215,9 @@ Published signals include Ash metadata in `signal.extensions["jido_metadata"]`.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `only` | list(atom) | all actions | Limit generated actions |
+| `only` | list(atom) | all public actions | Limit generated actions |
 | `except` | list(atom) | `[]` | Exclude actions |
+| `include_private?` | boolean | `false` | Include Ash actions with `public?: false` for trusted/internal tool catalogs |
 | `category` | string | `ash.<action_type>` | Category added to generated actions |
 | `tags` | list(string) | `[]` | Tags added to all generated actions |
 | `vsn` | string | `nil` | Optional semantic version metadata for generated actions |

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -89,11 +89,21 @@ This generates Jido.Action modules for each exposed action:
 
 ## Exposing All Actions
 
-Use `all_actions` to quickly expose all actions on a resource with smart defaults:
+Use `all_actions` to quickly expose all public Ash actions on a resource with smart defaults:
 
 ```elixir
 jido do
   all_actions
+end
+```
+
+`all_actions` uses Ash's public API boundary and skips actions with
+`public?: false` by default. Use explicit `action :name` entries for deliberate
+per-action exposure, or opt into a trusted/internal catalog:
+
+```elixir
+jido do
+  all_actions include_private?: true
 end
 ```
 
@@ -208,6 +218,7 @@ Each action in the `jido` section supports these options:
 - `read_load` for static read relationship loading
 - `read_query_params?` to enable/disable query parameters for read actions
 - `read_max_page_size` to set maximum page size for read actions
+- `include_private?` to include Ash actions with `public?: false` in trusted/internal catalogs
 - `category` (default `ash.<action_type>`)
 - `tags`
 - `vsn`

--- a/lib/ash_jido.ex
+++ b/lib/ash_jido.ex
@@ -65,9 +65,14 @@ defmodule AshJido do
         all_actions
         all_actions except: [:destroy]
         all_actions only: [:create, :read]
+        all_actions include_private?: true
         all_actions category: "ash.resource", tags: ["public-api"], vsn: "1.0.0"
         all_actions only: [:read], read_load: [:profile]
       end
+
+  `all_actions` uses Ash's public API boundary by default and expands only
+  actions with `public?: true`. Set `include_private?: true` only for trusted
+  internal tool catalogs.
 
   ## Action Options
 

--- a/lib/ash_jido/resource/all_actions.ex
+++ b/lib/ash_jido/resource/all_actions.ex
@@ -16,6 +16,7 @@ defmodule AshJido.Resource.AllActions do
     :signal_source,
     :__spark_metadata__,
     emit_signals?: false,
+    include_private?: false,
     telemetry?: false,
     read_query_params?: true
   ]
@@ -32,6 +33,7 @@ defmodule AshJido.Resource.AllActions do
           signal_type: String.t() | nil,
           signal_source: String.t() | nil,
           emit_signals?: boolean(),
+          include_private?: boolean(),
           telemetry?: boolean(),
           read_query_params?: boolean()
         }

--- a/lib/ash_jido/resource/dsl.ex
+++ b/lib/ash_jido/resource/dsl.ex
@@ -161,8 +161,8 @@ defmodule AshJido.Resource.Dsl do
       describe: """
       Expose all Ash actions as Jido actions with smart defaults.
 
-      This creates Jido actions for all create, read, update, destroy, and custom actions
-      defined on the resource, using intelligent naming and categorization.
+      This creates Jido actions for public create, read, update, destroy, and custom
+      actions defined on the resource, using intelligent naming and categorization.
 
       ## Usage
 
@@ -185,6 +185,11 @@ defmodule AshJido.Resource.Dsl do
         only: [
           type: {:list, :atom},
           doc: "If specified, only generate actions for these action names"
+        ],
+        include_private?: [
+          type: :boolean,
+          default: false,
+          doc: "Include actions with `public?: false`. Intended only for trusted/internal tool catalogs."
         ],
         category: [
           type: :string,

--- a/lib/ash_jido/resource/transformers/generate_jido_actions.ex
+++ b/lib/ash_jido/resource/transformers/generate_jido_actions.ex
@@ -62,8 +62,9 @@ defmodule AshJido.Resource.Transformers.GenerateJidoActions do
   end
 
   defp expand_all_actions(_resource, all_actions, dsl_state) do
-    # Get all actions from the resource
-    all_ash_actions = get_all_ash_actions(dsl_state)
+    # Get the public action boundary by default, with an explicit opt-in for
+    # trusted/internal catalogs that intentionally expose private actions.
+    all_ash_actions = get_all_ash_actions(dsl_state, all_actions.include_private?)
 
     # Filter based on only/except options
     filtered_actions = filter_actions(all_ash_actions, all_actions)
@@ -96,8 +97,15 @@ defmodule AshJido.Resource.Transformers.GenerateJidoActions do
   end
 
   defp get_all_ash_actions(dsl_state) do
-    # Get all action types from the DSL state
-    Transformer.get_entities(dsl_state, [:actions])
+    Ash.Resource.Info.public_actions(dsl_state)
+  end
+
+  defp get_all_ash_actions(dsl_state, include_private?) do
+    if include_private? do
+      Transformer.get_entities(dsl_state, [:actions])
+    else
+      get_all_ash_actions(dsl_state)
+    end
   end
 
   defp filter_actions(ash_actions, %{only: only, except: _except}) when not is_nil(only) do

--- a/test/ash_jido/resource_test.exs
+++ b/test/ash_jido/resource_test.exs
@@ -43,6 +43,7 @@ defmodule AshJido.ResourceTest do
       assert all_actions.category == nil
       assert all_actions.tags == nil
       assert all_actions.vsn == nil
+      assert all_actions.include_private? == false
     end
   end
 end

--- a/test/ash_jido/transformers/generate_jido_actions_test.exs
+++ b/test/ash_jido/transformers/generate_jido_actions_test.exs
@@ -95,6 +95,70 @@ defmodule AshJido.Resource.Transformers.GenerateJidoActionsTest do
     end
   end
 
+  defmodule ResourceWithPrivateAction do
+    use Ash.Resource,
+      domain: nil,
+      extensions: [AshJido],
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:name, :string, allow_nil?: false)
+    end
+
+    actions do
+      defaults([:read])
+
+      create :register do
+        accept([:name])
+      end
+
+      read :internal_lookup do
+        public?(false)
+      end
+    end
+
+    jido do
+      all_actions()
+    end
+  end
+
+  defmodule ResourceWithPrivateActionOptIn do
+    use Ash.Resource,
+      domain: nil,
+      extensions: [AshJido],
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:name, :string, allow_nil?: false)
+    end
+
+    actions do
+      defaults([:read])
+
+      create :register do
+        accept([:name])
+      end
+
+      read :internal_lookup do
+        public?(false)
+      end
+    end
+
+    jido do
+      all_actions(include_private?: true)
+    end
+  end
+
   describe "transform/1" do
     test "returns an error when load is configured on a non-read action" do
       unique_suffix = System.unique_integer([:positive])
@@ -279,6 +343,34 @@ defmodule AshJido.Resource.Transformers.GenerateJidoActionsTest do
       assert read_module.tags() == ["metadata"]
       assert register_module.vsn() == "3.0.0"
       assert read_module.vsn() == "3.0.0"
+    end
+
+    test "all_actions only expands public Ash actions by default" do
+      dsl_state = ResourceWithPrivateAction.spark_dsl_config()
+      {:ok, transformed_state} = GenerateJidoActions.transform(dsl_state)
+
+      generated_modules =
+        Spark.Dsl.Extension.get_persisted(transformed_state, :generated_jido_modules)
+
+      generated_names = Enum.map(generated_modules, & &1.name())
+
+      assert "create_resource_with_private_action" in generated_names
+      assert "list_resource_with_private_actions" in generated_names
+      refute "resource_with_private_action_internal_lookup" in generated_names
+      refute Enum.any?(generated_modules, &String.contains?(inspect(&1), "InternalLookup"))
+    end
+
+    test "all_actions can explicitly include private Ash actions" do
+      dsl_state = ResourceWithPrivateActionOptIn.spark_dsl_config()
+      {:ok, transformed_state} = GenerateJidoActions.transform(dsl_state)
+
+      generated_modules =
+        Spark.Dsl.Extension.get_persisted(transformed_state, :generated_jido_modules)
+
+      generated_module_names = Enum.map(generated_modules, &inspect/1)
+
+      assert Enum.any?(generated_module_names, &String.ends_with?(&1, ".Jido.Register"))
+      assert Enum.any?(generated_module_names, &String.ends_with?(&1, ".Jido.InternalLookup"))
     end
   end
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -25,8 +25,14 @@ jido do
   # or with filtering
   all_actions except: [:internal_action, :admin_only]
   all_actions only: [:create, :read, :update]
+  # trusted/internal catalogs only
+  all_actions include_private?: true
 end
 ```
+
+- `all_actions` expands only Ash actions with `public?: true` by default
+- Use explicit `action :private_action` entries for deliberate per-action private exposure
+- Use `include_private?: true` only for trusted/internal tool catalogs
 
 ## Naming Conventions
 


### PR DESCRIPTION
## Summary
- Expand `all_actions` from Ash public actions by default
- Add `include_private?: true` for trusted/internal catalogs that intentionally expose private actions
- Cover default exclusion and opt-in inclusion with transformer tests
- Document the public action boundary in README, getting started, moduledocs, and usage rules

## Verification
- mix test test/ash_jido/resource_test.exs test/ash_jido/transformers/generate_jido_actions_test.exs
- mix test
- mix quality

Closes #21