### PR TITLE
feat: filter generated schemas to public inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ than once.
 `all_actions` follows Ash's public API boundary by default: it expands only actions
 marked `public?: true`. Explicit `action :name` entries remain the way to expose a
 specific private action deliberately, and `include_private?: true` is available for
-trusted/internal tool catalogs.
+trusted/internal tool catalogs. Generated schemas also follow Ash's public input
+boundary by default and omit accepted attributes or action arguments marked
+`public?: false`.
 
 ```elixir
 jido do
@@ -202,6 +204,7 @@ Published signals include Ash metadata in `signal.extensions["jido_metadata"]`.
 | `tags` | list(string) | `[]` | Tags for categorization |
 | `vsn` | string | `nil` | Optional semantic version metadata |
 | `output_map?` | boolean | `true` | Convert structs to maps |
+| `include_private?` | boolean | `false` | Include inputs with `public?: false` in generated schemas for trusted/internal tools |
 | `load` | term | `nil` | Static `Ash.Query.load/2` for read actions |
 | `query_params?` | boolean | `true` | Enable query parameters (filter, sort, limit, offset, load) for read actions |
 | `max_page_size` | pos_integer | `nil` | Maximum limit value for read actions (clamps the limit parameter) |
@@ -217,7 +220,7 @@ Published signals include Ash metadata in `signal.extensions["jido_metadata"]`.
 |--------|------|---------|-------------|
 | `only` | list(atom) | all public actions | Limit generated actions |
 | `except` | list(atom) | `[]` | Exclude actions |
-| `include_private?` | boolean | `false` | Include Ash actions with `public?: false` for trusted/internal tool catalogs |
+| `include_private?` | boolean | `false` | Include Ash actions and inputs with `public?: false` for trusted/internal tool catalogs |
 | `category` | string | `ash.<action_type>` | Category added to generated actions |
 | `tags` | list(string) | `[]` | Tags added to all generated actions |
 | `vsn` | string | `nil` | Optional semantic version metadata for generated actions |
@@ -289,6 +292,10 @@ AshJido.Tools.tools(MyApp.Accounts.User)
 | `:read` (`:by_id`) | `get_<resource>_by_id` | `get_user_by_id` |
 | `:update` | `update_<resource>` | `update_user` |
 | `:destroy` | `delete_<resource>` | `delete_user` |
+
+Generated schemas are the public tool surface for discovery and validation. Ash
+authorization, policies, and runtime validation remain the source of truth when an
+action executes.
 
 ## Troubleshooting
 

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -107,6 +107,12 @@ jido do
 end
 ```
 
+Generated schemas also use Ash's public input boundary by default. Accepted
+attributes and action arguments marked `public?: false` are omitted from the
+Jido schema unless `include_private?: true` is set for a trusted/internal tool.
+This controls tool exposure; Ash authorization, policies, and runtime validation
+remain authoritative when the action executes.
+
 You can filter which actions to expose:
 
 ```elixir
@@ -204,6 +210,7 @@ Each action in the `jido` section supports these options:
 | `tags` | `list(string)` | `[]` | Tags for categorization and AI discovery |
 | `vsn` | `string` | `nil` | Optional semantic version metadata |
 | `output_map?` | `boolean` | `true` | Convert output structs to maps |
+| `include_private?` | `boolean` | `false` | Include inputs with `public?: false` in generated schemas for trusted/internal tools |
 | `load` | `term` | `nil` | Static `Ash.Query.load/2` statement for read actions |
 | `query_params?` | `boolean` | `true` | Enable query parameters (filter, sort, limit, offset, load) for read actions |
 | `max_page_size` | `pos_integer` | `nil` | Maximum limit value for read actions (clamps the limit parameter) |
@@ -218,7 +225,7 @@ Each action in the `jido` section supports these options:
 - `read_load` for static read relationship loading
 - `read_query_params?` to enable/disable query parameters for read actions
 - `read_max_page_size` to set maximum page size for read actions
-- `include_private?` to include Ash actions with `public?: false` in trusted/internal catalogs
+- `include_private?` to include Ash actions and inputs with `public?: false` in trusted/internal catalogs
 - `category` (default `ash.<action_type>`)
 - `tags`
 - `vsn`

--- a/lib/ash_jido.ex
+++ b/lib/ash_jido.ex
@@ -72,7 +72,8 @@ defmodule AshJido do
 
   `all_actions` uses Ash's public API boundary by default and expands only
   actions with `public?: true`. Set `include_private?: true` only for trusted
-  internal tool catalogs.
+  internal tool catalogs. Generated schemas also omit accepted attributes and
+  action arguments marked `public?: false` unless `include_private?: true` is set.
 
   ## Action Options
 
@@ -83,6 +84,7 @@ defmodule AshJido do
   - `tags` - List of tags for categorization (default: `[]`)
   - `vsn` - Optional semantic version identifier for generated action metadata
   - `output_map?` - Convert output structs to maps (default: `true`)
+  - `include_private?` - Include private inputs in generated schemas for trusted/internal tools (default: `false`)
   - `load` - Static `Ash.Query.load/2` statement for read actions (default: `nil`)
   - `emit_signals?` - Emit Jido signals from Ash notifications on create/update/destroy (default: `false`)
   - `signal_dispatch` - Default dispatch configuration for emitted signals (default: `nil`)

--- a/lib/ash_jido/generator.ex
+++ b/lib/ash_jido/generator.ex
@@ -551,26 +551,31 @@ defmodule AshJido.Generator do
     case ash_action.type do
       :create ->
         # Create actions use accepted attributes plus action arguments
-        accepted_attrs = accepted_attributes_to_schema(resource, ash_action, dsl_state)
-        action_args = action_args_to_schema(ash_action.arguments || [])
+        accepted_attrs =
+          accepted_attributes_to_schema(resource, ash_action, dsl_state, jido_action)
+
+        action_args = action_args_to_schema(ash_action.arguments || [], jido_action)
         accepted_attrs ++ action_args
 
       :update ->
         # Update actions need primary key fields plus accepted attributes plus action arguments
         base = primary_key_to_schema(dsl_state, :update)
-        accepted_attrs = accepted_attributes_to_schema(resource, ash_action, dsl_state)
-        action_args = action_args_to_schema(ash_action.arguments || [])
+
+        accepted_attrs =
+          accepted_attributes_to_schema(resource, ash_action, dsl_state, jido_action)
+
+        action_args = action_args_to_schema(ash_action.arguments || [], jido_action)
         base ++ accepted_attrs ++ action_args
 
       :destroy ->
         # Destroy actions need primary key fields plus action arguments
         base = primary_key_to_schema(dsl_state, :destroy)
-        action_args = action_args_to_schema(ash_action.arguments || [])
+        action_args = action_args_to_schema(ash_action.arguments || [], jido_action)
         base ++ action_args
 
       _ ->
         # Read and custom actions use their declared arguments
-        base_schema = action_args_to_schema(ash_action.arguments || [])
+        base_schema = action_args_to_schema(ash_action.arguments || [], jido_action)
 
         if ash_action.type == :read and jido_action.query_params? do
           base_schema ++ build_query_params_schema(jido_action)
@@ -628,7 +633,7 @@ defmodule AshJido.Generator do
     ]
   end
 
-  defp accepted_attributes_to_schema(_resource, ash_action, dsl_state) do
+  defp accepted_attributes_to_schema(_resource, ash_action, dsl_state, jido_action) do
     # Get the list of accepted attribute names from the action
     accepted_names = ash_action.accept || []
 
@@ -637,16 +642,20 @@ defmodule AshJido.Generator do
 
     # Filter to only accepted attributes and convert to schema entries
     accepted_names
-    |> Enum.map(fn attr_name ->
+    |> Enum.flat_map(fn attr_name ->
       attr = Enum.find(all_attributes, &(&1.name == attr_name))
 
-      if attr do
-        {attr_name, attribute_to_nimble_options(attr)}
-      else
-        nil
+      cond do
+        is_nil(attr) ->
+          []
+
+        include_schema_input?(attr, jido_action) ->
+          [{attr_name, attribute_to_nimble_options(attr)}]
+
+        true ->
+          []
       end
     end)
-    |> Enum.reject(&is_nil/1)
   end
 
   defp primary_key_fields(dsl_state) do
@@ -707,11 +716,18 @@ defmodule AshJido.Generator do
     opts
   end
 
-  defp action_args_to_schema(arguments) do
-    Enum.map(arguments, fn arg ->
+  defp action_args_to_schema(arguments, jido_action) do
+    arguments
+    |> Enum.filter(&include_schema_input?(&1, jido_action))
+    |> Enum.map(fn arg ->
       {arg.name, TypeMapper.ash_type_to_nimble_options(arg.type, arg)}
     end)
   end
+
+  defp include_schema_input?(_input, %{include_private?: true}), do: true
+
+  defp include_schema_input?(%{public?: false}, _jido_action), do: false
+  defp include_schema_input?(_input, _jido_action), do: true
 
   defp pluralize(word) do
     cond do

--- a/lib/ash_jido/resource/dsl.ex
+++ b/lib/ash_jido/resource/dsl.ex
@@ -111,6 +111,12 @@ defmodule AshJido.Resource.Dsl do
           default: true,
           doc: "Convert output structs to maps (recommended for AI tools)"
         ],
+        include_private?: [
+          type: :boolean,
+          default: false,
+          doc:
+            "Include inputs with `public?: false` in the generated schema. Intended only for trusted/internal tool catalogs."
+        ],
         load: [
           type: :any,
           doc: "Static Ash.Query.load statement to apply to generated read actions"
@@ -189,7 +195,7 @@ defmodule AshJido.Resource.Dsl do
         include_private?: [
           type: :boolean,
           default: false,
-          doc: "Include actions with `public?: false`. Intended only for trusted/internal tool catalogs."
+          doc: "Include actions and inputs with `public?: false`. Intended only for trusted/internal tool catalogs."
         ],
         category: [
           type: :string,

--- a/lib/ash_jido/resource/jido_action.ex
+++ b/lib/ash_jido/resource/jido_action.ex
@@ -18,6 +18,7 @@ defmodule AshJido.Resource.JidoAction do
     :signal_source,
     :__spark_metadata__,
     emit_signals?: false,
+    include_private?: false,
     telemetry?: false,
     output_map?: true,
     query_params?: true
@@ -37,6 +38,7 @@ defmodule AshJido.Resource.JidoAction do
           signal_type: String.t() | nil,
           signal_source: String.t() | nil,
           emit_signals?: boolean(),
+          include_private?: boolean(),
           telemetry?: boolean(),
           output_map?: boolean(),
           query_params?: boolean()

--- a/lib/ash_jido/resource/transformers/generate_jido_actions.ex
+++ b/lib/ash_jido/resource/transformers/generate_jido_actions.ex
@@ -89,6 +89,7 @@ defmodule AshJido.Resource.Transformers.GenerateJidoActions do
         signal_type: all_actions.signal_type,
         signal_source: all_actions.signal_source,
         telemetry?: all_actions.telemetry? || false,
+        include_private?: all_actions.include_private? || false,
         output_map?: true,
         query_params?: if(ash_action.type == :read, do: all_actions.read_query_params?, else: false),
         max_page_size: if(ash_action.type == :read, do: all_actions.read_max_page_size)

--- a/test/ash_jido/generator_test.exs
+++ b/test/ash_jido/generator_test.exs
@@ -118,6 +118,31 @@ defmodule AshJido.GeneratorTest do
     end
   end
 
+  defmodule PublicInputResource do
+    use Ash.Resource,
+      domain: nil,
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:public_name, :string, allow_nil?: false, public?: true)
+      attribute(:internal_code, :string, public?: false)
+    end
+
+    actions do
+      create :create do
+        accept([:public_name, :internal_code])
+
+        argument(:public_reason, :string, allow_nil?: false, public?: true)
+        argument(:internal_reason, :string, public?: false)
+      end
+    end
+  end
+
   defmodule PrimaryKeyDomain do
     use Ash.Domain, validate_config_inclusion?: false
 
@@ -243,6 +268,51 @@ defmodule AshJido.GeneratorTest do
       assert_raise RuntimeError, ~r/Action non_existent not found/, fn ->
         Generator.generate_jido_action_module(TestResource, jido_action, dsl_state)
       end
+    end
+
+    test "schema excludes non-public accepted attributes and action arguments by default" do
+      dsl_state = PublicInputResource.spark_dsl_config()
+
+      jido_action = %AshJido.Resource.JidoAction{
+        action: :create,
+        name: "public_input_schema",
+        module_name: TestPublicInputSchemaAction,
+        description: "Public input schema",
+        output_map?: true
+      }
+
+      module_name =
+        Generator.generate_jido_action_module(PublicInputResource, jido_action, dsl_state)
+
+      schema = module_name.schema()
+
+      assert Keyword.has_key?(schema, :public_name)
+      assert Keyword.has_key?(schema, :public_reason)
+      refute Keyword.has_key?(schema, :internal_code)
+      refute Keyword.has_key?(schema, :internal_reason)
+    end
+
+    test "schema includes non-public inputs when explicitly opted in" do
+      dsl_state = PublicInputResource.spark_dsl_config()
+
+      jido_action = %AshJido.Resource.JidoAction{
+        action: :create,
+        name: "private_input_schema",
+        module_name: TestPrivateInputSchemaAction,
+        description: "Private input schema",
+        include_private?: true,
+        output_map?: true
+      }
+
+      module_name =
+        Generator.generate_jido_action_module(PublicInputResource, jido_action, dsl_state)
+
+      schema = module_name.schema()
+
+      assert Keyword.has_key?(schema, :public_name)
+      assert Keyword.has_key?(schema, :public_reason)
+      assert Keyword.has_key?(schema, :internal_code)
+      assert Keyword.has_key?(schema, :internal_reason)
     end
   end
 

--- a/test/ash_jido/resource_test.exs
+++ b/test/ash_jido/resource_test.exs
@@ -33,6 +33,7 @@ defmodule AshJido.ResourceTest do
       assert jido_action.output_map? == true
       assert jido_action.emit_signals? == false
       assert jido_action.telemetry? == false
+      assert jido_action.include_private? == false
     end
 
     test "AllActions struct has expected defaults" do

--- a/test/ash_jido/transformers/generate_jido_actions_test.exs
+++ b/test/ash_jido/transformers/generate_jido_actions_test.exs
@@ -79,14 +79,15 @@ defmodule AshJido.Resource.Transformers.GenerateJidoActionsTest do
 
     attributes do
       uuid_primary_key(:id)
-      attribute(:name, :string, allow_nil?: false)
+      attribute(:name, :string, allow_nil?: false, public?: true)
+      attribute(:internal_code, :string, public?: false)
     end
 
     actions do
       defaults([:read])
 
       create :register do
-        accept([:name])
+        accept([:name, :internal_code])
       end
     end
 
@@ -107,14 +108,15 @@ defmodule AshJido.Resource.Transformers.GenerateJidoActionsTest do
 
     attributes do
       uuid_primary_key(:id)
-      attribute(:name, :string, allow_nil?: false)
+      attribute(:name, :string, allow_nil?: false, public?: true)
+      attribute(:internal_code, :string, public?: false)
     end
 
     actions do
       defaults([:read])
 
       create :register do
-        accept([:name])
+        accept([:name, :internal_code])
       end
 
       read :internal_lookup do
@@ -371,6 +373,50 @@ defmodule AshJido.Resource.Transformers.GenerateJidoActionsTest do
 
       assert Enum.any?(generated_module_names, &String.ends_with?(&1, ".Jido.Register"))
       assert Enum.any?(generated_module_names, &String.ends_with?(&1, ".Jido.InternalLookup"))
+    end
+
+    test "all_actions include_private? propagates private input schema exposure" do
+      unique_suffix = System.unique_integer([:positive])
+      resource_module = Module.concat(__MODULE__, :"PrivateInputResource#{unique_suffix}")
+
+      resource_ast =
+        quote do
+          defmodule unquote(resource_module) do
+            use Ash.Resource,
+              domain: nil,
+              extensions: [AshJido],
+              data_layer: Ash.DataLayer.Ets
+
+            ets do
+              private?(true)
+            end
+
+            attributes do
+              uuid_primary_key(:id)
+              attribute(:name, :string, allow_nil?: false, public?: true)
+              attribute(:internal_code, :string, public?: false)
+            end
+
+            actions do
+              create :create do
+                accept([:name, :internal_code])
+              end
+            end
+
+            jido do
+              all_actions(include_private?: true)
+            end
+          end
+        end
+
+      Code.compile_quoted(resource_ast)
+
+      assert Keyword.has_key?(Module.concat([resource_module, "Jido", "Create"]).schema(), :name)
+
+      assert Keyword.has_key?(
+               Module.concat([resource_module, "Jido", "Create"]).schema(),
+               :internal_code
+             )
     end
   end
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -32,7 +32,9 @@ end
 
 - `all_actions` expands only Ash actions with `public?: true` by default
 - Use explicit `action :private_action` entries for deliberate per-action private exposure
-- Use `include_private?: true` only for trusted/internal tool catalogs
+- Generated schemas expose only public accepted attributes and public action arguments by default
+- Use `include_private?: true` only for trusted/internal tool catalogs that may expose private actions or inputs
+- Ash authorization, policies, and runtime validation remain authoritative when actions execute
 
 ## Naming Conventions
 


### PR DESCRIPTION
## Summary
- Omit accepted attributes and action arguments with `public?: false` from generated Jido schemas by default
- Add `include_private?: true` to explicit `action` entries for trusted/internal private input exposure
- Propagate `all_actions include_private?: true` to generated action schema input exposure
- Document the schema exposure boundary versus Ash runtime authorization/policies

## Verification
- mix test test/ash_jido/generator_test.exs test/ash_jido/transformers/generate_jido_actions_test.exs test/ash_jido/resource_test.exs
- mix test
- mix quality

Closes #25