### PR TITLE
refactor: consolidate signal emission

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,10 @@ jido do
 end
 ```
 
-### Reactive Signals (Phase 1)
+### Reactive Signals
 
-Add `AshJido.Notifier` to the resource and configure publications in `jido`:
+The canonical Ash integration path is `AshJido.Notifier`: add it to the resource and configure
+publications in `jido` when you want resource lifecycle events published to a Jido signal bus:
 
 ```elixir
 defmodule MyApp.Post do
@@ -191,7 +192,11 @@ defmodule MyApp.Post do
 end
 ```
 
-Published signals include Ash metadata in `signal.extensions["jido_metadata"]`.
+Generated actions can also emit signals with `emit_signals?: true`; this is best when a tool run
+needs runtime dispatch overrides or telemetry signal counters. Both paths build payloads through
+`AshJido.SignalFactory`, so signal type/source/subject and `signal.extensions["jido_metadata"]`
+are consistent. Generated-action signals include all Ash attributes in `signal.data`; notifier
+publications use the configured `include` mode.
 
 ### Action Options
 

--- a/ash_jido_consumer/test/integration/ash_jido_real_integration_test.exs
+++ b/ash_jido_consumer/test/integration/ash_jido_real_integration_test.exs
@@ -209,8 +209,9 @@ defmodule AshJidoConsumer.RealIntegrationTest do
                )
 
       assert_receive {:signal, %Jido.Signal{} = create_signal}
-      assert create_signal.data.action == :create
-      assert create_signal.data.resource == Post
+      assert create_signal.data.title == "Signal Post"
+      assert signal_metadata(create_signal).ash_action == :create
+      assert signal_metadata(create_signal).ash_resource == Post
       assert create_signal.type == "ash_jido_consumer.content.post.created"
       assert create_signal.source == "/ash_jido_consumer/content/post"
 
@@ -222,15 +223,17 @@ defmodule AshJidoConsumer.RealIntegrationTest do
 
       assert updated[:title] == "Signal Post Updated"
       assert_receive {:signal, %Jido.Signal{} = update_signal}
-      assert update_signal.data.action == :update
-      assert update_signal.data.resource == Post
+      assert update_signal.data.title == "Signal Post Updated"
+      assert signal_metadata(update_signal).ash_action == :update
+      assert signal_metadata(update_signal).ash_resource == Post
 
       assert {:ok, %{deleted: true}} =
                Post.Jido.Destroy.run(%{id: created[:id]}, dispatch_context)
 
       assert_receive {:signal, %Jido.Signal{} = destroy_signal}
-      assert destroy_signal.data.action == :destroy
-      assert destroy_signal.data.resource == Post
+      assert destroy_signal.data.id == created[:id]
+      assert signal_metadata(destroy_signal).ash_action == :destroy
+      assert signal_metadata(destroy_signal).ash_resource == Post
     end
 
     test "missing dispatch config returns a validation error before execution" do
@@ -512,6 +515,13 @@ defmodule AshJidoConsumer.RealIntegrationTest do
       )
 
     handler_id
+  end
+
+  defp signal_metadata(signal) do
+    Map.get(signal, :jido_metadata) ||
+      signal
+      |> Map.get(:extensions, %{})
+      |> Map.get("jido_metadata", %{})
   end
 
   defp flush_telemetry_messages do

--- a/ash_jido_consumer/test/integration/guide_walkthrough_test.exs
+++ b/ash_jido_consumer/test/integration/guide_walkthrough_test.exs
@@ -87,7 +87,8 @@ defmodule AshJidoConsumer.GuideWalkthroughTest do
                )
 
       assert_receive {:signal, %Jido.Signal{} = signal}
-      assert signal.data.action == :create
+      assert signal.data.title == "Signal Guide Post"
+      assert signal_metadata(signal).ash_action == :create
 
       assert_receive {:telemetry_event, [:jido, :action, :ash_jido, :start], _start, _start_meta}
       assert_receive {:telemetry_event, [:jido, :action, :ash_jido, :stop], stop, stop_meta}
@@ -112,6 +113,13 @@ defmodule AshJidoConsumer.GuideWalkthroughTest do
       )
 
     handler_id
+  end
+
+  defp signal_metadata(signal) do
+    Map.get(signal, :jido_metadata) ||
+      signal
+      |> Map.get(:extensions, %{})
+      |> Map.get("jido_metadata", %{})
   end
 
   defp flush_telemetry_messages do

--- a/guides/walkthrough-signals-telemetry-sensors.md
+++ b/guides/walkthrough-signals-telemetry-sensors.md
@@ -30,6 +30,20 @@ Behavior is opt-in:
 - No signals are emitted unless `emit_signals?` is `true`.
 - No telemetry is emitted unless `telemetry?` is `true`.
 
+`AshJido.Notifier` remains the recommended Ash-native path for resource lifecycle publications to
+a Jido signal bus. Generated actions use the same `AshJido.SignalFactory` payload builder when
+`emit_signals?` is enabled, then dispatch the signal through `signal_dispatch`.
+
+Both paths produce the same envelope conventions:
+
+- `signal.type` is `{prefix}.{resource_short_name}.{action_name}` unless explicitly overridden.
+- `signal.source` follows `/ash/{resource_short_name}/{action_type}/{action_name}` unless explicitly overridden.
+- `signal.subject` identifies the primary key as `/{resource_short_name}/{id}` when available.
+- `signal.extensions["jido_metadata"]` includes Ash resource, action, action type, and timestamp metadata.
+
+Generated-action signals put all available Ash attributes in `signal.data`. Notifier publications
+use the publication `include` mode (`:pkey_only`, `:all`, `:changes_only`, or selected fields).
+
 ## 2. Dispatch to a Runtime Target
 
 Runtime context can override DSL dispatch configuration:
@@ -45,6 +59,7 @@ context = %{
 assert_receive {:signal, %Jido.Signal{} = signal}
 signal.type
 signal.source
+signal.data
 ```
 
 If signaling is enabled and no dispatch config can be resolved (DSL or context), execution fails early with a validation-style error.

--- a/lib/ash_jido/notifier.ex
+++ b/lib/ash_jido/notifier.ex
@@ -42,7 +42,7 @@ defmodule AshJido.Notifier do
           end
         end)
 
-      publish_signals(bus, signals)
+      dispatch_signals(bus, signals, resource, action_name)
     else
       {:error, :no_publications} ->
         :ok
@@ -121,18 +121,11 @@ defmodule AshJido.Notifier do
 
   defp resolve_bus(bus), do: {:ok, bus}
 
-  defp publish_signals(_bus, []), do: :ok
+  defp dispatch_signals(_bus, [], _resource, _action_name), do: :ok
 
-  defp publish_signals(bus, signals) do
-    case Jido.Signal.Bus.publish(bus, signals) do
-      {:ok, _recorded_signals} ->
-        :ok
-
-      {:error, reason} ->
-        Logger.error("AshJido.Notifier failed to publish signals to #{inspect(bus)}: #{inspect(reason)}")
-
-        :ok
-    end
+  defp dispatch_signals(bus, signals, resource, action_name) do
+    _result = AshJido.SignalEmitter.emit_signals(signals, {:ash_jido_bus, bus}, resource, action_name)
+    :ok
   end
 
   defp passes_condition?(%{condition: nil}, _notification), do: true

--- a/lib/ash_jido/signal_emitter.ex
+++ b/lib/ash_jido/signal_emitter.ex
@@ -4,6 +4,7 @@ defmodule AshJido.SignalEmitter do
   require Logger
 
   alias Jido.Action.Error
+  alias Jido.Signal
 
   @doc false
   @spec validate_dispatch_config(map(), struct(), module(), atom(), atom()) ::
@@ -56,11 +57,16 @@ defmodule AshJido.SignalEmitter do
     notifications
     |> List.wrap()
     |> Enum.reduce(%{sent: 0, failed: []}, fn notification, acc ->
+      notification = ensure_action_name(notification, action_name)
+
       with {:ok, signal} <-
-             notification_to_signal(notification, resource, action_name, jido_config),
-           :ok <- dispatch_signal(signal, dispatch) do
+             AshJido.SignalFactory.from_notification(notification, jido_config),
+           %{sent: 1, failed: []} <- emit_signals([signal], dispatch, resource, action_name) do
         %{acc | sent: acc.sent + 1}
       else
+        %{sent: 0, failed: [failure]} ->
+          %{acc | failed: [Map.put(failure, :notification, notification) | acc.failed]}
+
         {:error, reason} ->
           failure = %{
             reason: reason,
@@ -68,6 +74,32 @@ defmodule AshJido.SignalEmitter do
           }
 
           Logger.warning("AshJido failed to emit signal for #{inspect(resource)}.#{action_name}: #{inspect(reason)}")
+
+          %{acc | failed: [failure | acc.failed]}
+      end
+    end)
+    |> Map.update!(:failed, &Enum.reverse/1)
+  end
+
+  @doc false
+  @spec emit_signals([Signal.t()], term(), module(), atom()) :: %{sent: non_neg_integer(), failed: [map()]}
+  def emit_signals(signals, dispatch, resource, action_name) do
+    signals
+    |> List.wrap()
+    |> Enum.reduce(%{sent: 0, failed: []}, fn signal, acc ->
+      case dispatch_signal(signal, dispatch) do
+        :ok ->
+          %{acc | sent: acc.sent + 1}
+
+        {:error, reason} ->
+          failure = %{
+            reason: reason,
+            signal: signal
+          }
+
+          Logger.warning(
+            "AshJido failed to dispatch signal for #{inspect(resource)}.#{action_name}: #{inspect(reason)}"
+          )
 
           %{acc | failed: [failure | acc.failed]}
       end
@@ -85,67 +117,32 @@ defmodule AshJido.SignalEmitter do
     end
   end
 
-  defp notification_to_signal(notification, resource, action_name, jido_config) do
-    signal_type = jido_config.signal_type || default_signal_type(resource, action_name)
-    source = jido_config.signal_source || default_signal_source(resource)
-    subject = extract_subject(notification.data)
+  defp ensure_action_name(%Ash.Notifier.Notification{action: %{name: name}} = notification, _action_name)
+       when not is_nil(name),
+       do: notification
 
-    attrs =
-      [source: source]
-      |> maybe_put_subject(subject)
+  defp ensure_action_name(%Ash.Notifier.Notification{action: action} = notification, action_name)
+       when is_map(action) do
+    %{notification | action: Map.put(action, :name, action_name)}
+  end
 
-    data = %{
-      action: action_name,
-      action_type: extract_action_type(notification),
-      metadata: notification.metadata,
-      resource: resource,
-      result: notification.data
-    }
-
-    Jido.Signal.new(signal_type, data, attrs)
+  defp ensure_action_name(%Ash.Notifier.Notification{} = notification, action_name) do
+    %{notification | action: %{name: action_name, type: nil}}
   end
 
   defp dispatch_signal(_signal, nil), do: {:error, :missing_dispatch}
+
+  defp dispatch_signal(signal, {:ash_jido_bus, bus}) do
+    case Jido.Signal.Bus.publish(bus, [signal]) do
+      {:ok, _recorded_signals} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
   defp dispatch_signal(signal, dispatch) do
     case Jido.Signal.Dispatch.dispatch(signal, dispatch) do
       :ok -> :ok
       {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp maybe_put_subject(attrs, nil), do: attrs
-  defp maybe_put_subject(attrs, subject), do: Keyword.put(attrs, :subject, subject)
-
-  defp default_signal_type(resource, action_name) do
-    resource_segment =
-      resource
-      |> Module.split()
-      |> List.last()
-      |> Macro.underscore()
-
-    "ash_jido.#{resource_segment}.#{action_name}"
-  end
-
-  defp default_signal_source(resource) do
-    resource_segments =
-      resource
-      |> Module.split()
-      |> Enum.map(&Macro.underscore/1)
-      |> Enum.join("/")
-
-    "/ash_jido/#{resource_segments}"
-  end
-
-  defp extract_subject(%{id: id}) when not is_nil(id), do: to_string(id)
-  defp extract_subject(%{id: id}) when is_nil(id), do: nil
-  defp extract_subject(%_{} = struct), do: extract_subject(Map.from_struct(struct))
-  defp extract_subject(_), do: nil
-
-  defp extract_action_type(notification) do
-    case notification.action do
-      %{type: type} -> type
-      _ -> nil
     end
   end
 end

--- a/lib/ash_jido/signal_factory.ex
+++ b/lib/ash_jido/signal_factory.ex
@@ -19,14 +19,31 @@ defmodule AshJido.SignalFactory do
   @type reason :: term()
 
   @doc """
-  Builds a `Jido.Signal` from an Ash notifier notification and publication config.
+  Builds a `Jido.Signal` from an Ash notifier notification and signal configuration.
   """
   @spec from_notification(Notification.t(), Publication.t()) ::
           {:ok, Signal.t()} | {:error, reason()}
   def from_notification(%Notification{} = notification, %Publication{} = publication) do
+    build_signal(notification, publication, source: nil)
+  end
+
+  @spec from_notification(Notification.t(), map()) ::
+          {:ok, Signal.t()} | {:error, reason()}
+  def from_notification(%Notification{} = notification, signal_config) when is_map(signal_config) do
+    publication = %Publication{
+      actions: [notification.action.name],
+      signal_type: Map.get(signal_config, :signal_type),
+      include: :all,
+      metadata: []
+    }
+
+    build_signal(notification, publication, source: Map.get(signal_config, :signal_source))
+  end
+
+  defp build_signal(%Notification{} = notification, %Publication{} = publication, opts) do
     signal_type = resolve_signal_type(notification, publication)
     signal_data = build_signal_data(notification, publication)
-    signal_source = build_source(notification)
+    signal_source = Keyword.get(opts, :source) || build_source(notification)
     signal_metadata = build_metadata(notification, publication)
 
     with {:ok, signal} <-

--- a/test/ash_jido/signal_emitter_test.exs
+++ b/test/ash_jido/signal_emitter_test.exs
@@ -191,7 +191,9 @@ defmodule AshJido.SignalEmitterTest do
       assert result.sent == 1
       assert result.failed == []
 
-      assert_receive {:signal, %Jido.Signal{}}, 500
+      assert_receive {:signal, %Jido.Signal{} = signal}, 500
+      assert signal.data == %{id: "123", name: "Test"}
+      assert signal_metadata(signal).ash_action == :create
     end
 
     test "tracks failed emissions" do
@@ -371,8 +373,7 @@ defmodule AshJido.SignalEmitterTest do
         jido_config
       )
 
-      # Default type should be "ash_jido.user.create"
-      assert_receive {:signal, %Jido.Signal{type: "ash_jido.user.create"}}, 500
+      assert_receive {:signal, %Jido.Signal{type: "ash.user.create"}}, 500
     end
 
     test "generates correct default signal source from resource" do
@@ -402,8 +403,7 @@ defmodule AshJido.SignalEmitterTest do
         jido_config
       )
 
-      # Default source should be "/ash_jido/ash_jido/test/user"
-      assert_receive {:signal, %Jido.Signal{source: "/ash_jido/ash_jido/test/user"}}, 500
+      assert_receive {:signal, %Jido.Signal{source: "/ash/user/create/create"}}, 500
     end
 
     test "extracts subject from data with id" do
@@ -433,7 +433,7 @@ defmodule AshJido.SignalEmitterTest do
         jido_config
       )
 
-      assert_receive {:signal, %Jido.Signal{subject: "user-123"}}, 500
+      assert_receive {:signal, %Jido.Signal{subject: "/user/user-123"}}, 500
     end
 
     test "handles data without id for subject" do
@@ -465,5 +465,12 @@ defmodule AshJido.SignalEmitterTest do
 
       assert_receive {:signal, %Jido.Signal{subject: nil}}, 500
     end
+  end
+
+  defp signal_metadata(signal) do
+    Map.get(signal, :jido_metadata) ||
+      signal
+      |> Map.get(:extensions, %{})
+      |> Map.get("jido_metadata", %{})
   end
 end

--- a/test/ash_jido/signal_factory_test.exs
+++ b/test/ash_jido/signal_factory_test.exs
@@ -170,6 +170,37 @@ defmodule AshJido.SignalFactoryTest do
       assert {:ok, signal} = SignalFactory.from_notification(notification, publication)
       assert signal.subject == "/reactive_resource/abc-123"
     end
+
+    test "generated-action config uses the same canonical notification payload" do
+      notification = build_notification(:create, base_record(%{id: "123", name: "Generated"}))
+
+      jido_action = %AshJido.Resource.JidoAction{
+        action: :create,
+        signal_type: nil,
+        signal_source: nil
+      }
+
+      assert {:ok, signal} = SignalFactory.from_notification(notification, jido_action)
+      assert signal.type == "test.reactive_resource.create"
+      assert signal.source == "/ash/reactive_resource/create/create"
+      assert signal.subject == "/reactive_resource/123"
+      assert signal.data.name == "Generated"
+      assert signal_metadata(signal).ash_action == :create
+    end
+
+    test "generated-action config can override signal type and source" do
+      notification = build_notification(:create, base_record(%{id: "123"}))
+
+      jido_action = %AshJido.Resource.JidoAction{
+        action: :create,
+        signal_type: "custom.generated.created",
+        signal_source: "/custom/generated"
+      }
+
+      assert {:ok, signal} = SignalFactory.from_notification(notification, jido_action)
+      assert signal.type == "custom.generated.created"
+      assert signal.source == "/custom/generated"
+    end
   end
 
   defp build_notification(action_name, data, opts \\ []) do

--- a/test/integration/guide_examples_test.exs
+++ b/test/integration/guide_examples_test.exs
@@ -320,7 +320,8 @@ defmodule AshJido.GuideExamplesTest do
                )
 
       assert_receive {:signal, %Jido.Signal{} = signal}
-      assert signal.data.action == :create
+      assert signal.data.title == "Signal Post"
+      assert signal_metadata(signal).ash_action == :create
 
       assert_receive {:telemetry_event, [:jido, :action, :ash_jido, :start], start, start_meta}
       assert start.system_time > 0
@@ -433,6 +434,13 @@ defmodule AshJido.GuideExamplesTest do
       )
 
     handler_id
+  end
+
+  defp signal_metadata(signal) do
+    Map.get(signal, :jido_metadata) ||
+      signal
+      |> Map.get(:extensions, %{})
+      |> Map.get("jido_metadata", %{})
   end
 
   defp flush_telemetry_messages do

--- a/test/integration/signal_emission_test.exs
+++ b/test/integration/signal_emission_test.exs
@@ -94,8 +94,11 @@ defmodule AshJido.SignalEmissionTest do
       {:ok, _resource} = ResourceWithSignals.Jido.Create.run(%{title: "Create Signal"}, context)
 
       assert_receive {:signal, %Jido.Signal{} = signal}
-      assert signal.data.action == :create
-      assert signal.data.resource == ResourceWithSignals
+      assert signal.type == "ash.resource_with_signals.create"
+      assert signal.source == "/ash/resource_with_signals/create/create"
+      assert signal.data.title == "Create Signal"
+      assert signal_metadata(signal).ash_action == :create
+      assert signal_metadata(signal).ash_resource == ResourceWithSignals
     end
 
     test "update actions emit notification signals" do
@@ -107,8 +110,10 @@ defmodule AshJido.SignalEmissionTest do
 
       assert updated[:title] == "After"
       assert_receive {:signal, %Jido.Signal{} = signal}
-      assert signal.data.action == :update
-      assert signal.data.resource == ResourceWithSignals
+      assert signal.type == "ash.resource_with_signals.update"
+      assert signal.data.title == "After"
+      assert signal_metadata(signal).ash_action == :update
+      assert signal_metadata(signal).ash_resource == ResourceWithSignals
     end
 
     test "destroy actions emit notification signals" do
@@ -121,8 +126,10 @@ defmodule AshJido.SignalEmissionTest do
                ResourceWithSignals.Jido.Destroy.run(%{id: created[:id]}, context)
 
       assert_receive {:signal, %Jido.Signal{} = signal}
-      assert signal.data.action == :destroy
-      assert signal.data.resource == ResourceWithSignals
+      assert signal.type == "ash.resource_with_signals.destroy"
+      assert signal.data.id == created[:id]
+      assert signal_metadata(signal).ash_action == :destroy
+      assert signal_metadata(signal).ash_resource == ResourceWithSignals
     end
 
     test "returns validation error when emit_signals? is enabled and dispatch config is missing" do
@@ -233,5 +240,12 @@ defmodule AshJido.SignalEmissionTest do
       assert {:error, :runtime_unavailable} =
                AshJido.SensorDispatchBridge.forward_or_ignore(signal, :ash_jido_missing_runtime)
     end
+  end
+
+  defp signal_metadata(signal) do
+    Map.get(signal, :jido_metadata) ||
+      signal
+      |> Map.get(:extensions, %{})
+      |> Map.get("jido_metadata", %{})
   end
 end


### PR DESCRIPTION
## Summary

- Route generated-action signal payloads through `AshJido.SignalFactory` so generated actions and notifier publications share signal type/source/subject and metadata conventions.
- Route notifier bus publication through the shared `AshJido.SignalEmitter` dispatch accounting helper.
- Update signal tests and docs to describe the canonical notifier path and generated-action dispatch path.

## Verification

- `mix test test/ash_jido/signal_factory_test.exs test/ash_jido/signal_emitter_test.exs test/ash_jido/notifier_test.exs test/ash_jido/integration/publish_test.exs test/integration/signal_emission_test.exs test/integration/telemetry_test.exs test/integration/guide_examples_test.exs`
- `mix test`
- `mix quality`

Closes #27