### PR TITLE
docs: prepare 0.2.0 release notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Commands
 
 - Build: `mix compile`
-- Quality: `mix quality` (format check, compile warnings, credo, dialyzer)
+- Quality: `mix quality` (format check, compile warnings, credo, dialyzer, doctor)
 - Test all: `mix test`
 - Test single: `mix test test/path/to/test.exs:line_number`
 - Format: `mix format`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ The `mix quality` command runs the full quality check suite:
 - Compilation with warnings as errors
 - Credo static analysis
 - Dialyzer type checking
+- Documentation coverage (`mix doctor --raise`)
 
 ## Testing
 
@@ -105,6 +106,21 @@ git commit -m "feat(api)!: change action schema"
 - Reference any related issues
 - Include tests and documentation updates
 - Ensure CI passes
+
+## Release Checklist
+
+Before cutting a release:
+
+1. Confirm release notes and conventional commits cover the release content.
+2. Run `mix test`, `mix quality`, `mix docs`, and `mix coveralls`.
+3. Confirm README, guides, and `usage-rules.md` match the released behavior and
+   dependency baseline.
+4. Run the GitHub release workflow with `dry_run` first and inspect the
+   generated `CHANGELOG.md` output.
+5. Publish through the release workflow when the dry run is clean.
+
+Do not edit `CHANGELOG.md` directly in normal PRs; release automation generates
+it from conventional commits.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Or add manually to `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ash_jido, "~> 0.1.0"}
+    {:ash_jido, "~> 0.2.0"}
   ]
 end
 ```
@@ -112,7 +112,7 @@ AshJido resolves the Ash domain in this order:
 
 ```elixir
 context = %{
-  domain: MyApp.Accounts,       # optional override when the resource has domain: MyApp.Accounts
+  domain: MyApp.Accounts,       # required only when the resource has no static domain or you need an override
   actor: current_user,          # optional: for authorization
   tenant: "org_123",            # optional: for multi-tenancy
   authorize?: true,             # optional: explicit authorization mode
@@ -322,7 +322,9 @@ For a full error contract and telemetry interpretation, see [Walkthrough: Failur
 - Elixir: ~> 1.18
 - OTP: 27 or 28
 - Ash: ~> 3.12
-- Jido: ~> 2.0
+- Jido: ~> 2.2
+- Jido Action: ~> 2.2
+- Jido Signal: ~> 2.1
 
 ## Documentation
 
@@ -359,4 +361,4 @@ It exercises real integration scenarios end-to-end:
 
 ## License
 
-MIT
+Apache-2.0

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -9,7 +9,7 @@ Add `ash_jido` to your dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ash_jido, "~> 0.1"}
+    {:ash_jido, "~> 0.2"}
   ]
 end
 ```
@@ -183,7 +183,7 @@ The context map supports additional options for authorization and multi-tenancy:
 
 ```elixir
 context = %{
-  domain: MyApp.Accounts,       # Required: the Ash domain
+  domain: MyApp.Accounts,       # Required only when no static resource domain is configured or you need an override
   actor: current_user,          # Optional: for authorization policies
   tenant: "org_123",            # Optional: for multi-tenant apps
   authorize?: true,             # Optional: explicit authorization mode
@@ -230,6 +230,43 @@ Each action in the `jido` section supports these options:
 - `tags`
 - `vsn`
 - `emit_signals?`, `signal_dispatch`, `signal_type`, `signal_source`, and `telemetry?`
+
+### Signals
+
+Use `AshJido.Notifier` for Ash-native lifecycle publications to a Jido signal bus:
+
+```elixir
+defmodule MyApp.Blog.Post do
+  use Ash.Resource,
+    domain: MyApp.Blog,
+    extensions: [AshJido],
+    notifiers: [AshJido.Notifier]
+
+  jido do
+    signal_bus MyApp.SignalBus
+    signal_prefix "blog"
+
+    publish :create, "blog.post.created", include: [:id, :title]
+    publish_all :update, include: :changes_only
+  end
+end
+```
+
+Generated actions can also emit signals when a tool run needs runtime dispatch
+overrides or telemetry signal counters:
+
+```elixir
+jido do
+  action :create,
+    emit_signals?: true,
+    signal_dispatch: {:pid, target: self()},
+    telemetry?: true
+end
+```
+
+Both paths use `AshJido.SignalFactory`. Generated-action signals include all
+available Ash attributes in `signal.data`; notifier publications use the
+configured `include` mode.
 
 ### Telemetry
 

--- a/guides/release-notes-0-2-0.md
+++ b/guides/release-notes-0-2-0.md
@@ -1,0 +1,74 @@
+# Release Notes: 0.2.0 Preparation
+
+This maintainer note captures the intended `0.2.0` release content before the
+release workflow generates the final `CHANGELOG.md` entry.
+
+`CHANGELOG.md` is intentionally not edited by normal PRs. CI enforces this so
+`git_ops` can generate the final changelog from conventional commits during the
+GitHub release workflow.
+
+## Added
+
+- Read-action query parameters for generated actions: `filter`, `sort`, `limit`,
+  `offset`, and dynamic relationship `load`, with Ash safe input parsing and
+  optional `max_page_size` bounds.
+- Static resource-domain fallback, so generated actions use `context[:domain]`
+  first and then the resource's configured `domain:` before raising.
+- Public-surface schema generation that follows Ash `public?: true` inputs by
+  default, with `include_private?: true` available for trusted/internal tool
+  catalogs.
+- `all_actions` expansion over public Ash actions by default, plus
+  `only`/`except` filtering and trusted private-action opt-in.
+- Resource notification publishing through `AshJido.Notifier`, `publish`, and
+  `publish_all`, including configurable signal buses, prefixes, payload include
+  modes, metadata, and predicates.
+- Generated-action signal emission through `emit_signals?`, shared
+  `AshJido.SignalFactory` payload construction, runtime `signal_dispatch`
+  overrides, and signal delivery counters in telemetry metadata.
+- Opt-in generated-action telemetry under the Jido namespace:
+  `[:jido, :action, :ash_jido, :start | :stop | :exception]`.
+- `AshJido.Tools` helpers for exporting generated action modules and
+  LLM-friendly tool payloads.
+- `AshJido.SensorDispatchBridge` helpers for forwarding dispatched signal
+  messages into `Jido.Sensor.Runtime`.
+- A real AshPostgres consumer harness under `ash_jido_consumer/` covering
+  database-backed actions, policies, relationship loading, signals, and
+  telemetry.
+- Package quality infrastructure: shared GitHub Actions CI, docs and doctor
+  checks, coverage enforcement, release workflow, Dependabot for Mix and GitHub
+  Actions, and contributor docs.
+
+## Changed
+
+- Updated the dependency baseline to Elixir `~> 1.18`, Ash `~> 3.12`, Jido
+  `~> 2.2`, `jido_action ~> 2.2`, `jido_signal ~> 2.1`, `splode ~> 0.3`, and
+  `zoi ~> 0.17`.
+- Split generated action runtime execution out of the compile-time generator
+  into dedicated runtime/spec modules for clearer compile-time and runtime
+  boundaries.
+- Consolidated generated-action signal emission and notifier-driven
+  publications around the same signal factory and dispatch accounting path.
+- Documented explicit `module_name:` usage for intentionally exposing the same
+  Ash action more than once.
+
+## Fixed
+
+- Update and destroy actions now use the resource's primary key fields instead
+  of assuming a single `id` field.
+- Destroy actions pass declared Ash destroy action arguments through to Ash.
+- Non-map custom action results are wrapped so they satisfy `Jido.Exec` output
+  validation.
+- Multiple generated entries that would target the same module now fail at
+  compile time with guidance to provide explicit `module_name:` values.
+- README, guides, and usage rules now agree on naming, dependency compatibility,
+  context resolution, query parameters, signals, telemetry, tools, and release
+  tooling.
+
+## Intentional Notes
+
+- The final `CHANGELOG.md` entry, date, and tag should be produced by the GitHub
+  release workflow.
+- AshJido intentionally keeps the `AshJido` public module namespace for Ash DSL
+  extension compatibility; no namespace migration is included in this release.
+- The AshPostgres consumer harness remains a companion integration app, not part
+  of the published Hex package files.

--- a/mix.exs
+++ b/mix.exs
@@ -129,6 +129,7 @@ defmodule AshJido.MixProject do
         {"guides/walkthrough-failure-semantics.md", title: "Failure Semantics"},
         {"guides/walkthrough-tools-and-ai.md", title: "Tools and AI Integration"},
         {"guides/walkthrough-agent-tool-wiring.md", title: "Agent Tool Wiring"},
+        {"guides/release-notes-0-2-0.md", title: "0.2.0 Release Notes"},
         {"CHANGELOG.md", title: "Changelog"},
         {"CONTRIBUTING.md", title: "Contributing"},
         {"usage-rules.md", title: "Usage Rules"}
@@ -153,6 +154,7 @@ defmodule AshJido.MixProject do
           "guides/walkthrough-agent-tool-wiring.md"
         ],
         Project: [
+          "guides/release-notes-0-2-0.md",
           "CHANGELOG.md",
           "CONTRIBUTING.md",
           "usage-rules.md"

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -3,172 +3,279 @@
 ## Core Integration Patterns
 
 ### Resource Extension Setup
-- Always use `extensions: [AshJido]` in your Ash resource definition
-- Define the `jido` section after your `actions` section for clarity
-- Use the DSL to selectively expose actions as Jido tools
 
-### Action Exposure Strategies
+- Add `extensions: [AshJido]` to Ash resources that should generate Jido actions.
+- Put the `jido` section near the resource `actions` section so the exposed tool
+  surface is easy to audit.
+- Prefer explicit `action :name` entries for hand-curated tool catalogs.
+- Use `all_actions` when the resource's public Ash action surface is already the
+  intended tool surface.
 
-#### Individual Action Configuration
+### Individual Action Configuration
+
 ```elixir
 jido do
   action :create
-  action :read, name: "list_users", description: "List all users"
+  action :read, name: "list_users", description: "List users"
   action :update, tags: ["user-management", "data-modification"]
 end
 ```
 
-#### Bulk Action Exposure
+### Bulk Action Exposure
+
 ```elixir
 jido do
   all_actions
-  # or with filtering
   all_actions except: [:internal_action, :admin_only]
   all_actions only: [:create, :read, :update]
-  # trusted/internal catalogs only
-  all_actions include_private?: true
 end
 ```
 
-- `all_actions` expands only Ash actions with `public?: true` by default
-- Use explicit `action :private_action` entries for deliberate per-action private exposure
-- Generated schemas expose only public accepted attributes and public action arguments by default
-- Use `include_private?: true` only for trusted/internal tool catalogs that may expose private actions or inputs
-- Ash authorization, policies, and runtime validation remain authoritative when actions execute
+- `all_actions` expands only Ash actions with `public?: true` by default.
+- Generated schemas include only public accepted attributes and public action
+  arguments by default.
+- Use explicit `action :private_action` entries for deliberate private-action
+  exposure.
+- Use `include_private?: true` only for trusted/internal catalogs that may expose
+  private Ash actions or private inputs.
+- Ash authorization, policies, data-layer constraints, and runtime validation
+  remain authoritative when generated actions execute.
 
-## Naming Conventions
+## Naming and Modules
 
-### Default Naming Pattern
-- Auto-generated names follow: `{resource}_{action}` format
-- Examples: `user_create`, `post_update`, `comment_delete`
+### Default Action Names
 
-### Custom Naming
-- Use `name:` option for custom action names
-- Use `module_name:` for custom module naming
-- Keep names descriptive and AI-friendly
+- `:create` actions default to `"create_<resource>"`.
+- `:read` action `:read` defaults to `"list_<resources>"`.
+- `:read` action `:by_id` defaults to `"get_<resource>_by_id"`.
+- Other read actions default to `"<resource>_<action_name>"`.
+- `:update` actions default to `"update_<resource>"`.
+- `:destroy` actions default to `"delete_<resource>"`.
+- Custom actions default to `"<resource>_<action_name>"`, except common verbs
+  like `:activate` and `:archive`, which become `"<verb>_<resource>"`.
 
 ### Module Generation
-- Default modules: `MyApp.User.Jido.Create`
-- Custom modules: specify with `module_name:` option
+
+- Default modules are generated under the resource namespace, for example
+  `MyApp.Accounts.User.Jido.Create`.
+- `name:` changes the Jido action name used for discovery and tool payloads.
+- `module_name:` changes the generated Elixir module.
+- If the same Ash action is exposed more than once, give each entry an explicit
+  `module_name:` so modules do not collide.
 
 ## Context Requirements
 
-### Domain Configuration (REQUIRED)
-- **Domain is REQUIRED** - always provide `domain:` in action context
-- Use `%{domain: MyApp.Domain}` pattern
-- Actions will raise `ArgumentError` if domain is not provided
+AshJido resolves the Ash domain in this order:
 
-### Actor and Tenant
-- Include `actor:` for authorization
-- Include `tenant:` for multi-tenancy
-- Example: `%{domain: MyDomain, actor: current_user, tenant: "org_123"}`
+1. `context[:domain]`
+2. the resource's static `domain:` configuration
+3. `ArgumentError` if neither is available
 
-## Action Type Mappings
+```elixir
+context = %{
+  domain: MyApp.Accounts,
+  actor: current_user,
+  tenant: "org_123",
+  authorize?: true,
+  scope: MyApp.Scope.for(current_user),
+  context: %{request_id: "req_123"},
+  timeout: 15_000
+}
+```
 
-### CRUD Operations
-- `:create` actions → `data_creation` category
-- `:read` actions → `data_retrieval` category  
-- `:update` actions → `data_modification` category
-- `:destroy` actions → `data_deletion` category
+- Pass `actor:` for policy-aware authorization.
+- Pass `tenant:` for multi-tenant resources.
+- Pass `scope:` when using Ash scopes.
+- Pass `context:` for Ash action context metadata.
+- Pass `signal_dispatch:` to override generated-action signal dispatch at
+  runtime.
 
-### Custom Actions
-- `:action` type → `custom_operation` category
-- Use descriptive names for better AI discovery
-- Add relevant tags for categorization
+## Query Parameters
 
-## Parameter Handling
+Generated read actions accept optional query parameters by default:
 
-### Input Processing
-- String keys auto-converted to atoms when appropriate
-- Use standard Ash argument patterns
-- Include validation through NimbleOptions schemas
+```elixir
+MyApp.Blog.Post.Jido.Read.run(
+  %{
+    filter: %{status: %{in: ["draft", "published"]}},
+    sort: [%{"field" => "inserted_at", "direction" => "desc"}],
+    limit: 20,
+    offset: 40,
+    load: [:author, comments: [:author]]
+  },
+  %{domain: MyApp.Blog}
+)
+```
 
-### Output Formatting
-- Default: `output_map?: true` converts Ash structs to plain maps
-- Set `output_map?: false` to preserve Ash structs
-- Read actions return a list of records
-- Create/Update actions return the record
+- `filter` uses Ash `filter_input` syntax.
+- `sort` supports JSON-style maps, keyword lists, or strings like
+  `"-inserted_at,title"`.
+- `limit` and `offset` support pagination.
+- `load` supports atoms, lists, and nested keyword loads.
+- Query params use Ash's safe public input parsing and honor policies.
+- Disable query params with `query_params?: false`.
+- Bound result sizes with `max_page_size` or `read_max_page_size`.
+
+## Signals and Telemetry
+
+### Resource Publications
+
+Use `AshJido.Notifier` with `publish` or `publish_all` for Ash-native lifecycle
+publications to a Jido signal bus:
+
+```elixir
+defmodule MyApp.Blog.Post do
+  use Ash.Resource,
+    domain: MyApp.Blog,
+    extensions: [AshJido],
+    notifiers: [AshJido.Notifier]
+
+  jido do
+    signal_bus MyApp.SignalBus
+    signal_prefix "blog"
+
+    publish :create, "blog.post.created", include: [:id, :title]
+    publish_all :update, include: :changes_only
+  end
+end
+```
+
+`publish` supports `include: :pkey_only | :all | :changes_only | [:field]`,
+`metadata: [:actor, :tenant, :changes, :previous_state]`, and `condition: fun`.
+
+### Generated-Action Signals
+
+Use `emit_signals?: true` when signal dispatch should be tied to generated
+action execution:
+
+```elixir
+jido do
+  action :create,
+    emit_signals?: true,
+    signal_dispatch: {:pid, target: self()},
+    telemetry?: true
+end
+```
+
+- Generated-action signals require `signal_dispatch` from the DSL or context.
+- Both generated-action signals and notifier publications use
+  `AshJido.SignalFactory`.
+- Default signal types are `{prefix}.{resource}.{action}`.
+- Default signal sources are `/ash/{resource}/{action_type}/{action}`.
+- Default subjects are `/{resource}/{primary_key}` when a primary key exists.
+- Generated-action signals put all available Ash attributes in `signal.data`.
+- Notifier publications use the configured `include` mode for `signal.data`.
+- Ash metadata lives in `signal.extensions["jido_metadata"]`.
+
+### Telemetry
+
+Telemetry is opt-in with `telemetry?: true` and emits:
+
+- `[:jido, :action, :ash_jido, :start]`
+- `[:jido, :action, :ash_jido, :stop]`
+- `[:jido, :action, :ash_jido, :exception]`
+
+Telemetry metadata includes resource/action/module identity, domain and tenant
+presence, actor presence, read-load/query configuration, signal enablement, and
+signal delivery counters.
+
+## Tools and Sensor Bridge
+
+- Use `AshJido.Tools.actions/1` to list generated action modules for a resource
+  or domain.
+- Use `AshJido.Tools.tools/1` to export name/description/schema/function maps
+  for generic agent and LLM integrations.
+- Use `AshJido.SensorDispatchBridge.forward/2`, `forward_many/2`, or
+  `forward_or_ignore/2` to feed dispatched `Jido.Signal` messages into
+  `Jido.Sensor.Runtime`.
+
+## Output and Mutation Semantics
+
+- `output_map?: true` is the default and converts Ash structs to plain maps.
+- Set `output_map?: false` to preserve Ash structs.
+- Read actions return lists.
+- Create and update actions return the resulting record.
+- Update and destroy actions require the resource primary key fields in params.
+- Resources with the default `[:id]` primary key still use `id`.
+- Destroy actions also pass through declared Ash destroy action arguments.
+- Custom Ash actions use `Ash.run_action!`; non-map results are wrapped for
+  Jido output validation.
 
 ## Error Handling
 
-### Ash Error Conversion
-- Ash errors automatically wrapped as Jido.Error
-- Field-level validation errors preserved
-- Authorization errors mapped to appropriate Jido types
+Ash errors are converted to `Jido.Action.Error` exceptions:
 
-### Error Categories
-- `Ash.Error.Forbidden` → `:authorization_error`
-- `Ash.Error.Invalid` → `:validation_error`
-- `Ash.Error.Framework` → `:system_error`
-- `Ash.Error.Unknown` → `:execution_error`
+- `Ash.Error.Invalid` becomes `Jido.Action.Error.InvalidInputError`.
+- `Ash.Error.Forbidden` becomes `Jido.Action.Error.ExecutionFailureError` with
+  `details.reason == :forbidden`.
+- `Ash.Error.Framework` becomes `Jido.Action.Error.InternalError`.
+- `Ash.Error.Unknown` becomes `Jido.Action.Error.InternalError`.
+- Other exceptions become `Jido.Action.Error.ExecutionFailureError`.
+
+Field-level validation errors are preserved in `error.details.fields`, and the
+original Ash error is preserved in `error.details.ash_error`.
 
 ## Best Practices
 
 ### Security
-- Always use Ash policies for authorization
-- Don't expose sensitive actions without proper filtering
-- Use `except:` to exclude admin or internal actions
 
-### Performance
-- Consider `limit:` and `offset:` for large datasets
+- Prefer Ash `public?: true` boundaries for generated tool catalogs.
+- Use `include_private?: true` only for trusted/internal tools.
+- Keep Ash policies as the authorization source of truth.
+- Use `except:` or explicit action entries to avoid exposing destructive or
+  administrative actions unintentionally.
+- Bound large read actions with `max_page_size`.
 
 ### AI Integration
-- Add descriptive tags for better AI discovery
-- Use clear, descriptive action names
-- Include comprehensive descriptions
-- Tag actions by domain: `["user-management", "content", "analytics"]`
+
+- Use clear verb-first `name:` values for agent-facing tools.
+- Add concise `description:` text and focused `tags:`.
+- Use `category:` for routing; `all_actions` defaults to `"ash.<action_type>"`
+  when no category override is provided.
+- Export tool payloads through `AshJido.Tools.tools/1` for generic integrations.
+- For `Jido.AI.Agent`, configure generated action modules directly in `tools:`.
 
 ### Documentation
-- Leverage auto-generated module documentation
-- Actions inherit descriptions from Ash definitions
-- Custom descriptions override defaults
 
-## Common Patterns
-
-### User Management Resource
-```elixir
-jido do
-  action :create, name: "register_user"
-  action :read, name: "list_users", tags: ["user-management", "public"]
-  action :update, name: "update_profile"
-  action :destroy, name: "delete_account", tags: ["user-management", "destructive"]
-end
-```
-
-### Content Resource
-```elixir
-jido do
-  all_actions except: [:internal_update]
-  # Auto-generates: create_post, list_posts, update_post, delete_post
-end
-```
-
-### Custom Business Logic
-```elixir
-jido do
-  action :activate, name: "activate_user", tags: ["user-management", "state-change"]
-  action :calculate_metrics, tags: ["analytics", "reporting"]
-end
-```
+- Generated modules include docs pointing back to the Ash resource/action.
+- Keep README, guides, changelog, and these usage rules in sync when changing
+  DSL options, runtime behavior, or generated schemas.
+- Do not edit `CHANGELOG.md` directly in normal PRs; the release workflow
+  generates it from conventional commits through `git_ops`.
+- Run `mix docs` and `mix doctor --raise` after public documentation changes.
 
 ## Troubleshooting
 
-### Domain Not Provided Error
-- AshJido uses `context[:domain]` first, then the resource's static `domain:` configuration
-- Provide `%{domain: MyApp.Domain}` when overriding or when the resource has `domain: nil`
-- Ensure the resource is registered in the domain you're providing
+### Domain Not Provided
 
-### Action Not Found Error
-- Verify action exists in resource definition
-- Check spelling and exact action name
-- Ensure action is public (not private)
+- AshJido uses `context[:domain]` first, then the resource's static `domain:`.
+- Provide `%{domain: MyApp.Domain}` when overriding or when the resource has no
+  static domain.
+- Ensure the resource is registered in the provided domain.
 
-### Type Conversion Issues
-- Check Ash type → NimbleOptions mapping
-- Verify custom types are properly handled
-- Use string keys for JSON/API inputs
+### Action Not Found
+
+- Verify the action exists in the resource `actions` section.
+- Check spelling and exact action name.
+- For `all_actions`, ensure the action is public or opt in with
+  `include_private?: true`.
+
+### Query Parameter Errors
+
+- Confirm the target is a read action and `query_params?` is enabled.
+- Use public Ash attributes for `filter` and `sort`.
+- Use `max_page_size` to make pagination bounds explicit.
+
+### Signal Dispatch Errors
+
+- `emit_signals?: true` requires `signal_dispatch` in the DSL or context.
+- Use `AshJido.Notifier` and `signal_bus` for resource-level Jido bus
+  publications.
+- Use `signal_type` and `signal_source` only when the default envelope should be
+  overridden.
 
 ### Module Compilation Issues
-- Ensure Jido dependency is available
-- Check for circular dependencies
-- Verify proper extension loading order
+
+- Ensure `jido`, `jido_action`, and `jido_signal` dependencies are available.
+- Give duplicate generated entries explicit `module_name:` values.
+- Check for circular resource/module references.


### PR DESCRIPTION
## Summary
- add maintainer-facing 0.2.0 release notes that preserve the intended changelog content while leaving CHANGELOG.md to git_ops release automation
- reconcile README/getting-started/usage-rules around context fallback, query params, signals, telemetry, tools, dependencies, and license
- add maintainer release checklist and update AGENTS quality command notes

## Verification
- mix docs
- mix test
- mix quality
- mix doctor --raise
- mix coveralls
- git diff --check

Reference: https://jido.run/docs/contributors/package-quality-standards

Closes #30