### PR TITLE
fix: include belongs_to source attrs in schemas

### DIFF
--- a/lib/ash_jido/schema.ex
+++ b/lib/ash_jido/schema.ex
@@ -4,6 +4,8 @@ defmodule AshJido.Schema do
   alias AshJido.TypeMapper
   alias Spark.Dsl.Transformer
 
+  @default_belongs_to_type Application.compile_env(:ash, :default_belongs_to_type, :uuid)
+
   @doc false
   @spec build_parameter_schema(term(), AshJido.Resource.JidoAction.t(), Spark.Dsl.t()) ::
           keyword()
@@ -52,12 +54,12 @@ defmodule AshJido.Schema do
 
   defp accepted_attributes_to_schema(ash_action, dsl_state, jido_action) do
     accepted_names = ash_action.accept || []
-    all_attributes = Transformer.get_entities(dsl_state, [:attributes])
+    attributes_by_name = attributes_by_name(dsl_state)
     belongs_to_source_attributes = belongs_to_source_attributes(dsl_state)
 
     accepted_names
     |> Enum.flat_map(fn attr_name ->
-      attr = Enum.find(all_attributes, &(&1.name == attr_name))
+      attr = Map.get(attributes_by_name, attr_name)
       relationship = Map.get(belongs_to_source_attributes, attr_name)
 
       cond do
@@ -76,6 +78,12 @@ defmodule AshJido.Schema do
     end)
   end
 
+  defp attributes_by_name(dsl_state) do
+    dsl_state
+    |> Transformer.get_entities([:attributes])
+    |> Map.new(&{&1.name, &1})
+  end
+
   defp belongs_to_source_attributes(dsl_state) do
     dsl_state
     |> Transformer.get_entities([:relationships])
@@ -87,10 +95,10 @@ defmodule AshJido.Schema do
 
   defp primary_key_to_schema(dsl_state, action_type) do
     primary_key = primary_key_fields(dsl_state)
-    all_attributes = Transformer.get_entities(dsl_state, [:attributes])
+    attributes_by_name = attributes_by_name(dsl_state)
 
     Enum.map(primary_key, fn attr_name ->
-      attr = Enum.find(all_attributes, &(&1.name == attr_name))
+      attr = Map.get(attributes_by_name, attr_name)
 
       opts =
         case attr do
@@ -139,7 +147,7 @@ defmodule AshJido.Schema do
       end
 
     TypeMapper.ash_type_to_nimble_options(
-      relationship.attribute_type || Application.get_env(:ash, :default_belongs_to_type, :uuid),
+      relationship.attribute_type || @default_belongs_to_type,
       %{allow_nil?: allow_nil?}
     )
   end

--- a/lib/ash_jido/schema.ex
+++ b/lib/ash_jido/schema.ex
@@ -53,21 +53,35 @@ defmodule AshJido.Schema do
   defp accepted_attributes_to_schema(ash_action, dsl_state, jido_action) do
     accepted_names = ash_action.accept || []
     all_attributes = Transformer.get_entities(dsl_state, [:attributes])
+    belongs_to_source_attributes = belongs_to_source_attributes(dsl_state)
 
     accepted_names
     |> Enum.flat_map(fn attr_name ->
       attr = Enum.find(all_attributes, &(&1.name == attr_name))
+      relationship = Map.get(belongs_to_source_attributes, attr_name)
 
       cond do
-        is_nil(attr) ->
+        attr && include_schema_input?(attr, jido_action) ->
+          [{attr_name, attribute_to_nimble_options(attr)}]
+
+        attr ->
           []
 
-        include_schema_input?(attr, jido_action) ->
-          [{attr_name, attribute_to_nimble_options(attr)}]
+        relationship && include_source_attribute_schema_input?(relationship, jido_action) ->
+          [{attr_name, relationship_source_attribute_to_nimble_options(relationship)}]
 
         true ->
           []
       end
+    end)
+  end
+
+  defp belongs_to_source_attributes(dsl_state) do
+    dsl_state
+    |> Transformer.get_entities([:relationships])
+    |> Enum.filter(&(&1.type == :belongs_to))
+    |> Map.new(fn relationship ->
+      {relationship.source_attribute || :"#{relationship.name}_id", relationship}
     end)
   end
 
@@ -116,6 +130,20 @@ defmodule AshJido.Schema do
     end
   end
 
+  defp relationship_source_attribute_to_nimble_options(relationship) do
+    allow_nil? =
+      if relationship.primary_key? do
+        false
+      else
+        relationship.allow_nil?
+      end
+
+    TypeMapper.ash_type_to_nimble_options(
+      relationship.attribute_type || Application.get_env(:ash, :default_belongs_to_type, :uuid),
+      %{allow_nil?: allow_nil?}
+    )
+  end
+
   defp action_args_to_schema(arguments, jido_action) do
     arguments
     |> Enum.filter(&include_schema_input?(&1, jido_action))
@@ -128,4 +156,14 @@ defmodule AshJido.Schema do
 
   defp include_schema_input?(%{public?: false}, _jido_action), do: false
   defp include_schema_input?(_input, _jido_action), do: true
+
+  defp include_source_attribute_schema_input?(_relationship, %{include_private?: true}), do: true
+
+  defp include_source_attribute_schema_input?(%{attribute_public?: false}, _jido_action),
+    do: false
+
+  defp include_source_attribute_schema_input?(%{attribute_public?: true}, _jido_action), do: true
+
+  defp include_source_attribute_schema_input?(relationship, jido_action),
+    do: include_schema_input?(relationship, jido_action)
 end

--- a/lib/ash_jido/type_mapper.ex
+++ b/lib/ash_jido/type_mapper.ex
@@ -53,7 +53,7 @@ defmodule AshJido.TypeMapper do
   Maps an Ash type to its corresponding NimbleOptions type.
   """
   def map_ash_type(ash_type) do
-    case ash_type do
+    case Ash.Type.get_type(ash_type) do
       Ash.Type.String -> :string
       Ash.Type.Integer -> :integer
       Ash.Type.Float -> :float

--- a/test/ash_jido/type_mapper_test.exs
+++ b/test/ash_jido/type_mapper_test.exs
@@ -71,6 +71,15 @@ defmodule AshJido.TypeMapperTest do
       assert result[:required] == true
     end
 
+    test "maps Ash DSL type short names correctly" do
+      result = TypeMapper.ash_type_to_nimble_options(:uuid, %{allow_nil?: false})
+      assert result[:type] == :string
+      assert result[:required] == true
+
+      result = TypeMapper.ash_type_to_nimble_options(:integer, %{})
+      assert result[:type] == :integer
+    end
+
     test "maps array types recursively" do
       # Array of strings
       result = TypeMapper.ash_type_to_nimble_options({:array, Ash.Type.String}, %{})

--- a/test/integration/relationship_load_test.exs
+++ b/test/integration/relationship_load_test.exs
@@ -106,6 +106,14 @@ defmodule AshJido.RelationshipLoadTest do
   end
 
   describe "relationship-aware reads" do
+    test "create schema includes accepted belongs_to source attributes" do
+      schema = ArticleWithActionLoad.Jido.Create.schema()
+
+      assert schema[:title][:required] == true
+      assert schema[:author_id][:type] == :string
+      assert schema[:author_id][:required] == true
+    end
+
     test "action load applies static read relationship load" do
       author =
         Author

--- a/test/integration/relationship_load_test.exs
+++ b/test/integration/relationship_load_test.exs
@@ -63,6 +63,96 @@ defmodule AshJido.RelationshipLoadTest do
     end
   end
 
+  defmodule IntegerAuthor do
+    use Ash.Resource,
+      domain: nil,
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      attribute(:id, :integer, primary_key?: true, allow_nil?: false, public?: true)
+      attribute(:name, :string, allow_nil?: false, public?: true)
+    end
+
+    actions do
+      defaults([:read])
+    end
+  end
+
+  defmodule ArticleWithCustomSourceAttribute do
+    use Ash.Resource,
+      domain: nil,
+      extensions: [AshJido],
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:title, :string, allow_nil?: false, public?: true)
+    end
+
+    relationships do
+      belongs_to(:writer, IntegerAuthor,
+        source_attribute: :writer_ref,
+        attribute_type: :integer,
+        allow_nil?: false,
+        public?: true
+      )
+    end
+
+    actions do
+      create :create do
+        accept([:title, :writer_ref])
+      end
+    end
+
+    jido do
+      action(:create, name: "create_article_custom_source_attribute")
+    end
+  end
+
+  defmodule ArticleWithPrivateRelationshipSource do
+    use Ash.Resource,
+      domain: nil,
+      extensions: [AshJido],
+      data_layer: Ash.DataLayer.Ets
+
+    ets do
+      private?(true)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:title, :string, allow_nil?: false, public?: true)
+    end
+
+    relationships do
+      belongs_to(:author, Author, allow_nil?: false, public?: false)
+    end
+
+    actions do
+      create :create do
+        accept([:title, :author_id])
+      end
+    end
+
+    jido do
+      action(:create, name: "create_article_private_relationship_source")
+
+      action(:create,
+        name: "create_article_private_relationship_source_internal",
+        module_name: AshJido.RelationshipLoadTest.ArticleWithPrivateRelationshipSource.InternalCreate,
+        include_private?: true
+      )
+    end
+  end
+
   defmodule ArticleWithAllActionsReadLoad do
     use Ash.Resource,
       domain: nil,
@@ -100,7 +190,10 @@ defmodule AshJido.RelationshipLoadTest do
 
     resources do
       resource(Author)
+      resource(IntegerAuthor)
       resource(ArticleWithActionLoad)
+      resource(ArticleWithCustomSourceAttribute)
+      resource(ArticleWithPrivateRelationshipSource)
       resource(ArticleWithAllActionsReadLoad)
     end
   end
@@ -112,6 +205,28 @@ defmodule AshJido.RelationshipLoadTest do
       assert schema[:title][:required] == true
       assert schema[:author_id][:type] == :string
       assert schema[:author_id][:required] == true
+
+      all_actions_schema = ArticleWithAllActionsReadLoad.Jido.Create.schema()
+
+      assert all_actions_schema[:author_id][:type] == :string
+      assert all_actions_schema[:author_id][:required] == true
+    end
+
+    test "create schema uses custom belongs_to source attribute names and types" do
+      schema = ArticleWithCustomSourceAttribute.Jido.Create.schema()
+
+      assert schema[:writer_ref][:type] == :integer
+      assert schema[:writer_ref][:required] == true
+      refute Keyword.has_key?(schema, :writer_id)
+    end
+
+    test "create schema respects private belongs_to source attributes" do
+      public_schema = ArticleWithPrivateRelationshipSource.Jido.Create.schema()
+      internal_schema = ArticleWithPrivateRelationshipSource.InternalCreate.schema()
+
+      refute Keyword.has_key?(public_schema, :author_id)
+      assert internal_schema[:author_id][:type] == :string
+      assert internal_schema[:author_id][:required] == true
     end
 
     test "action load applies static read relationship load" do


### PR DESCRIPTION
## Summary
- Resolve accepted `belongs_to` source attributes from relationship metadata when they are not present in the explicit attribute list.
- Map Ash DSL type short names before generating NimbleOptions schemas.
- Add regression coverage for `author_id` in generated create schemas.

## Testing
- `mix test`
- `mix quality`

Fixes #54